### PR TITLE
fix sm int tests

### DIFF
--- a/tests/sm_int/sm_int.c
+++ b/tests/sm_int/sm_int.c
@@ -140,7 +140,7 @@ static void waitAndDestroyEndOpenThreads(OPEN_CLOSE_THREADS* data)
     /*so:*/
     /*at this moment at best there is 1 sm_open_begin (sm_open_begin is mutually exclusive with self) that did not yet have its partner sm_open_end called.*/
     /*note: the loop below does not guarantee that any one of spawned threads calls it*/
-    /*here' how that might not happen: all callsEndOpen threads are Sleeping. Then they (all of them) wake up, they evaluate the condition "threadsShouldFinish", find it true, and exit.*/
+    /*here's how that might not happen: all callsEndOpen threads are Sleeping. Then they (all of them) wake up, they evaluate the condition "threadsShouldFinish", find it true, and exit.*/
     /*thus leaving the open_end not called*/
     for (uint32_t iEndOpen = 0; iEndOpen < data->n_end_open_threads; iEndOpen++)
     {
@@ -222,7 +222,7 @@ static void waitAndDestroyEndCloseThreads(OPEN_CLOSE_THREADS* data)
     /*so:*/
     /*at this moment at best there is 1 sm_close_begin (sm_close_begin is mutually exclusive with self) that did not yet have its partner sm_close_end called.*/
     /*note: the loop below does not guarantee that any one of spawned threads calls it*/
-    /*here' how that might not happen: all callsEndClose threads are Sleeping. Then they (all of them) wake up, they evaluate the condition "threadsShouldFinish", find it true, and exit.*/
+    /*here's how that might not happen: all callsEndClose threads are Sleeping. Then they (all of them) wake up, they evaluate the condition "threadsShouldFinish", find it true, and exit.*/
     /*thus leaving the sm_close_end not called*/
     for (uint32_t iEndClose = 0; iEndClose < data->n_end_close_threads; iEndClose++)
     {
@@ -301,7 +301,7 @@ static void waitAndDestroyEndBarrierThreads(OPEN_CLOSE_THREADS* data)
     /*so:*/
     /*at this moment at best there is 1 sm_barrier_begin (sm_barrier_begin is mutually exclusive with self) that did not yet have its partner sm_barrier_end called.*/
     /*note: the loop below does not guarantee that any one of spawned threads calls it*/
-    /*here' how that might not happen: all callsEndBarrier threads are Sleeping. Then they (all of them) wake up, they evaluate the condition "threadsShouldFinish", find it true, and exit.*/
+    /*here's how that might not happen: all callsEndBarrier threads are Sleeping. Then they (all of them) wake up, they evaluate the condition "threadsShouldFinish", find it true, and exit.*/
     /*thus leaving the sm_barrier_end not called*/
     for (uint32_t iEndBarrier = 0; iEndBarrier < data->n_end_barrier_threads; iEndBarrier++)
     {

--- a/tests/sm_int/sm_int.c
+++ b/tests/sm_int/sm_int.c
@@ -28,8 +28,6 @@ TEST_DEFINE_ENUM_TYPE(SM_RESULT, SM_RESULT_VALUES);
 TEST_DEFINE_ENUM_TYPE(THREADAPI_RESULT, THREADAPI_RESULT_VALUES);
 TEST_DEFINE_ENUM_TYPE(INTERLOCKED_HL_RESULT, INTERLOCKED_HL_RESULT_VALUES);
 
-#define XTEST_FUNCTION(x) void x(void)
-
 #define N_MAX_THREADS 256
 
 #define MIN(a,b) (((a) < (b)) ? (a) : (b))
@@ -643,7 +641,7 @@ TEST_FUNCTION(sm_chaos)
     xlogging_set_log_function(toBeRestored);
 }
 
-XTEST_FUNCTION(sm_does_not_block)
+TEST_FUNCTION(sm_does_not_block)
 {
     LogInfo("disabling logging for the duration of sm_does_not_block. Logging takes additional locks that \"might help\" the test pass");
     LOGGER_LOG toBeRestored = xlogging_get_log_function();
@@ -970,7 +968,7 @@ static void sm_switches_from_state_to_created(SM_GO_TO_STATE* goToState)
 /*at time=THREAD_TO_BACK_DELAY  an API is executed, result is collected and asserted*/
 /*at time = 2*THREAD_TO_BACK_DELAY the second thread unblocks execution and reverts execution to SM_CREATED*/
 
-XTEST_FUNCTION(STATE_and_API)
+TEST_FUNCTION(STATE_and_API)
 {
     SM_RESULT_AND_NEXT_STATE_AFTER_API_CALL expected[][4]=
     {


### PR DESCRIPTION
There are comments explaining the proper wind down of the testing threads in the chaos scenario.

This was tested by running the test on 64 parallel processes 1000 times and it is not hang anymore.