### PR TITLE
Add sm_fault and faulted state to state machine

### DIFF
--- a/devdoc/sm_requirements.md
+++ b/devdoc/sm_requirements.md
@@ -57,7 +57,7 @@ Barriers - since they are exclusive - are realized by switching to a state calle
 
 Close is realized by prohibiting all calls (including competing `sm_close_begin` calls) by setting a bit with `InterlockedOr`. `sm_close_begin` will wait for the state to reach `SM_OPENED` and the number of executing calls to be `0`. This allows an ongoing barrier to finish (and return to `SM_OPENED` state), or the executing APIs to finish.
 
-Fault is realized by prohibiting all calls (except for `sm_close_begin` calls and all `_end` calls) by setting a bit with `InterlockedOr`. `sm_fault` will not set the fault bit if the state is `SM_CREATED` or `SM_CLOSING`. This means that the module cannot fault while it is closed and any currently executing operations can complete.
+Fault is realized by prohibiting all calls (except for `sm_close_begin` calls and all `_end` calls) by setting a bit with `InterlockedOr`. `sm_fault` will not set the fault bit if the state is `SM_CREATED`. This means that the module cannot fault while it is closed and any currently executing operations can complete.
 
 `sm` will verify all sequence of calls. When a _begin call is called in an unexpected state, `sm` will refuse to grant the execution. `sm_exec_end` calls do not have a return value, but `sm` does protect internally against mismatched such calls. For example, `n` is decremented by `sm_exec_end`, but `sm` does not allow `n` to reach negative values.
 

--- a/devdoc/sm_requirements.md
+++ b/devdoc/sm_requirements.md
@@ -211,6 +211,8 @@ MOCKABLE_FUNCTION(, void, sm_close_end, SM_HANDLE, sm);
 
 **SRS_SM_02_044: [** `sm_close_end` shall switch the state to `SM_CREATED`. **]**
 
+**SRS_SM_42_012: [** `sm_close_end` shall not reset the `SM_FAULTED_BIT`. **]**
+
 ### sm_exec_begin
 ```c
 MOCKABLE_FUNCTION(, int, sm_exec_begin, SM_HANDLE, sm);
@@ -246,6 +248,8 @@ MOCKABLE_FUNCTION(, void, sm_exec_end, SM_HANDLE, sm);
 **SRS_SM_02_060: [** If state is not `SM_OPENED_DRAINING_TO_BARRIER` then `sm_exec_end` shall return. **]**
 
 **SRS_SM_02_061: [** If state is not `SM_OPENED_DRAINING_TO_CLOSE` then `sm_exec_end` shall return. **]**
+
+**SRS_SM_42_013: [** `sm_exec_end` may be called when `SM_FAULTED_BIT` is 1. **]**
 
 **SRS_SM_02_062: [** `sm_exec_end` shall decrement `n` with saturation at 0. **]**
 
@@ -288,6 +292,8 @@ MOCKABLE_FUNCTION(, void, sm_barrier_end, SM_HANDLE, sm);
 **SRS_SM_02_032: [** If `sm` is `NULL` then `sm_barrier_end` shall return. **]**
 
 **SRS_SM_02_072: [** If state is not `SM_OPENED_BARRIER` then `sm_barrier_end` shall return. **]**
+
+**SRS_SM_42_014: [** `sm_barrier_end` may be called when `SM_FAULTED_BIT` is 1. **]**
 
 **SRS_SM_02_073: [** `sm_barrier_end` shall switch the state to `SM_OPENED`. **]**
 

--- a/devdoc/sm_requirements.md
+++ b/devdoc/sm_requirements.md
@@ -251,6 +251,8 @@ MOCKABLE_FUNCTION(, void, sm_exec_end, SM_HANDLE, sm);
 
 **SRS_SM_02_063: [** If `n` reaches 0 then `sm_exec_end` shall signal that. **]**
 
+**SRS_SM_42_010: [** If `n` would decrement below 0, then `sm_exec_end` shall terminate the process. **]**
+
 ### sm_barrier_begin
 ```c
 MOCKABLE_FUNCTION(, int, sm_barrier_begin, SM_HANDLE, sm);
@@ -299,8 +301,6 @@ MOCKABLE_FUNCTION(, void, sm_fault, SM_HANDLE, sm);
 **SRS_SM_42_004: [** If `sm` is `NULL` then `sm_fault` shall return. **]**
 
 **SRS_SM_42_006: [** If the state is `SM_CREATED` then `sm_fault` shall return. **]**
-
-**SRS_SM_42_008: [** If the state is `SM_CLOSING` then `sm_fault` shall return. **]**
 
 **SRS_SM_42_007: [** `sm_fault` shall set `SM_FAULTED_BIT` to 1. **]**
 

--- a/inc/c_util/sm.h
+++ b/inc/c_util/sm.h
@@ -43,6 +43,8 @@ MOCKABLE_FUNCTION(, void, sm_exec_end, SM_HANDLE, sm);
 MOCKABLE_FUNCTION(, SM_RESULT, sm_barrier_begin, SM_HANDLE, sm);
 MOCKABLE_FUNCTION(, void, sm_barrier_end, SM_HANDLE, sm);
 
+MOCKABLE_FUNCTION(, void, sm_fault, SM_HANDLE, sm);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rc_string.c
+++ b/src/rc_string.c
@@ -188,19 +188,25 @@ IMPLEMENT_MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_custom_f
 
 THANDLE(RC_STRING) rc_string_recreate(THANDLE(RC_STRING) self)
 {
-    THANDLE(RC_STRING) result;
+    THANDLE(RC_STRING) result = NULL;
     if (self == NULL)
     {
         /*Codes_SRS_RC_STRING_02_001: [ If source is NULL then rc_string_recreate shall return NULL. ]*/
         LogError("invalid argument THANDLE(RC_STRING) self=%p", self);
-        THANDLE_INITIALIZE(RC_STRING)(&result, NULL);
+        /*return as is, that is, NULL*/
     }
     else
     {
         /*Codes_SRS_RC_STRING_02_002: [ rc_string_recreate shall perform same steps as rc_string_create to return a THANDLE(RC_STRING) with the same content as source. ]*/
         THANDLE(RC_STRING) temp = rc_string_create_impl(self->string);
-        THANDLE_INITIALIZE_MOVE(RC_STRING)(&result, &temp);
-        /*return as is*/
+
+        if (temp == NULL)
+        {
+            LogError("unable to recreate the string %" PRI_RC_STRING " with individual storage", RC_STRING_VALUE(self));
+        }
+
+        /*in any case (NULL, non-NULL) return it*/
+        THANDLE_INITIALIZE_MOVE(RC_STRING)(&result, &temp); 
     }
     return result;
 }

--- a/src/sm.c
+++ b/src/sm.c
@@ -29,16 +29,17 @@
 
 MU_DEFINE_ENUM(SM_STATE, SM_STATE_VALUES)
 
-#define SM_STATE_MASK       ((1<<7)-1) /*127*/
+#define SM_CLOSE_BIT        (1<<7)
+#define SM_FAULTED_BIT      (1<<6)
+#define SM_STATE_MASK       ((1<<6)-1) /*63*/
+
 #define SM_STATE_INCREMENT  (1<<8)  /*256*/ /*at every state change, the state is incremented by this much*/
 
-#define SM_CLOSE_BIT        (1<<7)
-
 /*a PRI macro for the SM state*/
-#define PRI_SM_STATE "" PRI_MU_ENUM " SM_CLOSE_BIT=%d"
+#define PRI_SM_STATE "" PRI_MU_ENUM " SM_CLOSE_BIT=%d, SM_FAULTED_BIT=%d"
 
 /*a VALUE macro corresponding to PRI_SM_STATE - it takes SM_HANDLE_DATA.state as argument*/
-#define SM_STATE_VALUE(state) MU_ENUM_VALUE(SM_STATE, (SM_STATE)((state) & SM_STATE_MASK)), (((state)&SM_CLOSE_BIT)>0)
+#define SM_STATE_VALUE(state) MU_ENUM_VALUE(SM_STATE, (SM_STATE)((state) & SM_STATE_MASK)), (((state)&SM_CLOSE_BIT)>0), (((state)&SM_FAULTED_BIT)>0)
 
 typedef struct SM_HANDLE_DATA_TAG
 {
@@ -55,13 +56,13 @@ MU_DEFINE_ENUM_STRINGS(SM_STATE, SM_STATE_VALUES);
 SM_HANDLE sm_create(const char* name)
 {
     SM_HANDLE result;
-    
+
     /*Codes_SRS_SM_02_001: [ If name is NULL then sm_create shall behave as if name was "NO_NAME". ]*/
     if (name == NULL)
     {
-        name = NO_NAME; 
+        name = NO_NAME;
     }
-    
+
     size_t flexSize = strlen(name) + 1;
 
     /*Codes_SRS_SM_02_002: [ sm_create shall allocate memory for the instance. ]*/
@@ -176,8 +177,8 @@ void sm_open_end(SM_HANDLE sm, bool success)
             }
             else
             {
-                /*Codes_SRS_SM_02_075: [ If success is false then sm_open_end shall switch the state to SM_CREATED. ]*/
-                if (interlocked_compare_exchange(&sm->state, state - SM_OPENING + SM_CREATED + SM_STATE_INCREMENT, state) != state)
+                /*Codes_SRS_SM_02_075: [ If success is false then sm_open_end shall switch the state to SM_CREATED and reset the SM_FAULTED_BIT to 0. ]*/
+                if (interlocked_compare_exchange(&sm->state, (state & ~(uint32_t)SM_FAULTED_BIT) - SM_OPENING + SM_CREATED + SM_STATE_INCREMENT, state) != state)
                 {
                     LogError("sm name=%s. sm_open_end state changed meanwhile (it was %" PRI_SM_STATE ", likely competing threads.", sm->name, SM_STATE_VALUE(state));
                 }
@@ -226,7 +227,7 @@ static SM_RESULT sm_close_begin_internal(SM_HANDLE sm)
                         result = SM_ERROR;
                         break;
                     }
-                    
+
                     /*Codes_SRS_SM_02_049: [ sm_close_begin shall switch the state to SM_CLOSING and return SM_EXEC_GRANTED. ]*/
                     (void)interlocked_add(&sm->state, -SM_OPENED_DRAINING_TO_CLOSE + SM_CLOSING + SM_STATE_INCREMENT);
                     result = SM_EXEC_GRANTED;
@@ -270,30 +271,36 @@ SM_RESULT sm_close_begin(SM_HANDLE sm)
     {
         result = sm_close_begin_internal(sm);
     }
-    
+
     return result;
 }
 
 static void sm_close_end_internal(SM_HANDLE sm)
 {
-    /*Codes_SRS_SM_02_043: [ If the state is not SM_CLOSING then sm_close_end shall return. ]*/
-    int32_t state = interlocked_add(&sm->state, 0);
-    if ((state & SM_STATE_MASK) != SM_CLOSING)
+    do
     {
-        LogError("sm name=%s. cannot sm_close_end_internal that which is in %" PRI_SM_STATE " state", sm->name, SM_STATE_VALUE(state));
-    }
-    else
-    {
-        /*Codes_SRS_SM_02_044: [ sm_close_end shall switch the state to SM_CREATED. ]*/
-        if (interlocked_compare_exchange(&sm->state, state - SM_CLOSING + SM_CREATED + SM_STATE_INCREMENT, state) != state)
+        /*Codes_SRS_SM_02_043: [ If the state is not SM_CLOSING then sm_close_end shall return. ]*/
+        int32_t state = interlocked_add(&sm->state, 0);
+        if ((state & SM_STATE_MASK) != SM_CLOSING)
         {
-            LogError("sm name=%s. state changed meanwhile (it was %" PRI_SM_STATE "), likely competing threads", sm->name, SM_STATE_VALUE(state));
+            LogError("sm name=%s. cannot sm_close_end_internal that which is in %" PRI_SM_STATE " state", sm->name, SM_STATE_VALUE(state));
+            break;
         }
         else
         {
-
+            /*Codes_SRS_SM_42_001: [ sm_close_end shall reset SM_FAULTED_BIT to 0. ]*/
+            /*Codes_SRS_SM_02_044: [ sm_close_end shall switch the state to SM_CREATED. ]*/
+            if (interlocked_compare_exchange(&sm->state, (state & ~(uint32_t)SM_FAULTED_BIT) - SM_CLOSING + SM_CREATED + SM_STATE_INCREMENT, state) != state)
+            {
+                LogError("sm name=%s. state changed meanwhile (it was %" PRI_SM_STATE "), likely competing threads", sm->name, SM_STATE_VALUE(state));
+                // Retry (maybe a fault happened during the close but after we checked the state above?)
+            }
+            else
+            {
+                break;
+            }
         }
-    }
+    } while (1);
 }
 
 void sm_close_end(SM_HANDLE sm)
@@ -325,7 +332,9 @@ SM_RESULT sm_exec_begin(SM_HANDLE sm)
             /*Codes_SRS_SM_02_054: [ If state is not SM_OPENED then sm_exec_begin shall return SM_EXEC_REFUSED. ]*/
             ((state1 & SM_STATE_MASK) != SM_OPENED) ||
             /*Codes_SRS_SM_02_055: [ If SM_CLOSE_BIT is 1 then sm_exec_begin shall return SM_EXEC_REFUSED. ]*/
-            ((state1 & SM_CLOSE_BIT) == SM_CLOSE_BIT)
+            ((state1 & SM_CLOSE_BIT) == SM_CLOSE_BIT) ||
+            /*Codes_SRS_SM_42_002: [ If SM_FAULTED_BIT is 1 then sm_exec_begin shall return SM_EXEC_REFUSED. ]*/
+            ((state1 & SM_FAULTED_BIT) == SM_FAULTED_BIT)
             )
         {
             LogError("sm name=%s. cannot call sm_exec_begin when state is %" PRI_SM_STATE "", sm->name, SM_STATE_VALUE(state1));
@@ -426,7 +435,9 @@ SM_RESULT sm_barrier_begin(SM_HANDLE sm)
             /*Codes_SRS_SM_02_064: [ If state is not SM_OPENED then sm_barrier_begin shall return SM_EXEC_REFUSED. ]*/
             ((state & SM_STATE_MASK) != SM_OPENED) ||
             /*Codes_SRS_SM_02_065: [ If SM_CLOSE_BIT is set to 1 then sm_barrier_begin shall return SM_EXEC_REFUSED. ]*/
-            ((state & SM_CLOSE_BIT) == SM_CLOSE_BIT)
+            ((state & SM_CLOSE_BIT) == SM_CLOSE_BIT) ||
+            /*Codes_SRS_SM_42_003: [ If SM_FAULTED_BIT is set to 1 then sm_barrier_begin shall return SM_EXEC_REFUSED. ]*/
+            ((state & SM_FAULTED_BIT) == SM_FAULTED_BIT)
             )
         {
             LogError("sm name=%s. cannot execute barrier begin when state is %" PRI_SM_STATE "", sm->name, SM_STATE_VALUE(state));
@@ -473,23 +484,71 @@ void sm_barrier_end(SM_HANDLE sm)
     }
     else
     {
-        int32_t state = interlocked_add(&sm->state, 0);
-        /*Codes_SRS_SM_02_072: [ If state is not SM_OPENED_BARRIER then sm_barrier_end shall return. ]*/
-        if ((state & SM_STATE_MASK) != SM_OPENED_BARRIER)
+        do
         {
-            LogError("sm name=%s. cannot call sm_barrier_end when state is %" PRI_SM_STATE "", sm->name, SM_STATE_VALUE(state));
-        }
-        else
-        {
-            /*Codes_SRS_SM_02_073: [ sm_barrier_end shall switch the state to SM_OPENED. ]*/
-            if (interlocked_compare_exchange(&sm->state, state - SM_OPENED_BARRIER + SM_OPENED + SM_STATE_INCREMENT, state) != state)
+            int32_t state = interlocked_add(&sm->state, 0);
+            /*Codes_SRS_SM_02_072: [ If state is not SM_OPENED_BARRIER then sm_barrier_end shall return. ]*/
+            if ((state & SM_STATE_MASK) != SM_OPENED_BARRIER)
             {
-                LogError("sm name=%s. state changed meanwhile (it was %" PRI_SM_STATE "), likely competing threads", sm->name, SM_STATE_VALUE(state));
+                LogError("sm name=%s. cannot call sm_barrier_end when state is %" PRI_SM_STATE "", sm->name, SM_STATE_VALUE(state));
+                break;
             }
             else
             {
-                /*it's all fine, we're back to SM_OPENED*/ /*let a close know about that, if any*/
+                /*Codes_SRS_SM_02_073: [ sm_barrier_end shall switch the state to SM_OPENED. ]*/
+                if (interlocked_compare_exchange(&sm->state, state - SM_OPENED_BARRIER + SM_OPENED + SM_STATE_INCREMENT, state) != state)
+                {
+                    LogError("sm name=%s. state changed meanwhile (it was %" PRI_SM_STATE "), likely competing threads", sm->name, SM_STATE_VALUE(state));
+                    // Retry, close may have started or a fault may have happened
+                }
+                else
+                {
+                    /*it's all fine, we're back to SM_OPENED*/ /*let a close know about that, if any*/
+                    break;
+                }
             }
-        }
+        } while (1);
+    }
+}
+
+void sm_fault(SM_HANDLE sm)
+{
+    if (sm == NULL)
+    {
+        /*Codes_SRS_SM_42_004: [ If sm is NULL then sm_fault shall return. ]*/
+        LogError("invalid arg SM_HANDLE sm=%p", sm);
+    }
+    else
+    {
+        // When this function returns the state must be one of the following (in the absence of other threads changing the state):
+        //   SM_CREATED
+        //   SM_CLOSING
+        //   have SM_FAULTED_BIT set in any other state
+        do
+        {
+            int32_t state = interlocked_add(&sm->state, 0);
+            if (
+                /*Codes_SRS_SM_42_006: [ If the state is SM_CREATED then sm_fault shall return. ]*/
+                ((state & SM_STATE_MASK) == SM_CREATED) ||
+                /*Codes_SRS_SM_42_008: [ If the state is SM_CLOSING then sm_fault shall return. ]*/
+                ((state & SM_STATE_MASK) == SM_CLOSING)
+                )
+            {
+                LogError("sm name=%s. cannot execute barrier begin when state is %" PRI_SM_STATE "", sm->name, SM_STATE_VALUE(state));
+                break;
+            }
+            else
+            {
+                /*Codes_SRS_SM_42_007: [ sm_fault shall set SM_FAULTED_BIT to 1. ]*/
+                if (interlocked_compare_exchange(&sm->state, (state | SM_FAULTED_BIT) + SM_STATE_INCREMENT, state) != state)
+                {
+                    /*Codes_SRS_SM_42_009: [ While the state changes before setting the bit then sm_fault shall re-evaluate the state. ]*/
+                }
+                else
+                {
+                    break;
+                }
+            }
+        } while (1);
     }
 }

--- a/src/sm.c
+++ b/src/sm.c
@@ -302,6 +302,7 @@ static void sm_close_end_internal(SM_HANDLE sm)
         else
         {
             /*Codes_SRS_SM_02_044: [ sm_close_end shall switch the state to SM_CREATED. ]*/
+            /*Codes_SRS_SM_42_012: [ sm_close_end shall not reset the SM_FAULTED_BIT. ]*/
             if (interlocked_compare_exchange(&sm->state, state - SM_CLOSING + SM_CREATED + SM_STATE_INCREMENT, state) != state)
             {
                 LogError("sm name=%s. state changed meanwhile (it was %" PRI_SM_STATE "), likely competing threads", sm->name, SM_STATE_VALUE(state));
@@ -389,6 +390,7 @@ void sm_exec_end(SM_HANDLE sm)
     else
     {
         int32_t state = interlocked_add(&sm->state, 0);
+        /*Codes_SRS_SM_42_013: [ sm_exec_end may be called when SM_FAULTED_BIT is 1. ]*/
         if (
             /*Codes_SRS_SM_02_059: [ If state is not SM_OPENED then sm_exec_end shall return. ]*/
             ((state & SM_STATE_MASK) != SM_OPENED) &&
@@ -501,9 +503,10 @@ void sm_barrier_end(SM_HANDLE sm)
         do
         {
             int32_t state = interlocked_add(&sm->state, 0);
-            /*Codes_SRS_SM_02_072: [ If state is not SM_OPENED_BARRIER then sm_barrier_end shall return. ]*/
+            /*Codes_SRS_SM_42_014: [ sm_barrier_end may be called when SM_FAULTED_BIT is 1. ]*/
             if ((state & SM_STATE_MASK) != SM_OPENED_BARRIER)
             {
+                /*Codes_SRS_SM_02_072: [ If state is not SM_OPENED_BARRIER then sm_barrier_end shall return. ]*/
                 LogError("sm name=%s. cannot call sm_barrier_end when state is %" PRI_SM_STATE "", sm->name, SM_STATE_VALUE(state));
                 break;
             }

--- a/tests/reals/real_sm.h
+++ b/tests/reals/real_sm.h
@@ -19,7 +19,8 @@
         sm_exec_begin,                                  \
         sm_exec_end,                                    \
         sm_barrier_begin,                               \
-        sm_barrier_end                                  \
+        sm_barrier_end,                                 \
+        sm_fault                                        \
     )
 
 #include "c_util/sm.h"
@@ -42,6 +43,8 @@ void real_sm_exec_end(SM_HANDLE sm);
 
 SM_RESULT real_sm_barrier_begin(SM_HANDLE sm);
 void real_sm_barrier_end(SM_HANDLE sm);
+
+void real_sm_fault(SM_HANDLE sm);
 
 #ifdef __cplusplus
 }

--- a/tests/reals/real_sm_renames.h
+++ b/tests/reals/real_sm_renames.h
@@ -11,6 +11,7 @@
 #define sm_exec_end         real_sm_exec_end
 #define sm_barrier_begin    real_sm_barrier_begin
 #define sm_barrier_end      real_sm_barrier_end
+#define sm_fault            real_sm_fault
 
 #define SM_RESULT           real_SM_RESULT
 #define SM_STATE            real_SM_STATE

--- a/tests/sm_int/sm_int.c
+++ b/tests/sm_int/sm_int.c
@@ -872,7 +872,7 @@ TEST_FUNCTION(sm_chaos)
 
     xlogging_set_log_function(toBeRestored);
 }
-#if 0
+
 TEST_FUNCTION(sm_does_not_block)
 {
     LogInfo("disabling logging for the duration of sm_does_not_block. Logging takes additional locks that \"might help\" the test pass");
@@ -1366,5 +1366,5 @@ TEST_FUNCTION(STATE_and_API)
         }
     }
 }
-#endif
+
 END_TEST_SUITE(sm_int_tests)

--- a/tests/sm_int/sm_int.c
+++ b/tests/sm_int/sm_int.c
@@ -47,6 +47,7 @@ typedef struct OPEN_CLOSE_THREADS_TAG
     THREAD_HANDLE endOpenThreads[N_MAX_THREADS];
     volatile_atomic int32_t n_begin_open_grants;
     volatile_atomic int32_t n_begin_open_refuses;
+    volatile_atomic int32_t begin_open_pending; // Track begin_open for when end_open should be called (0 or 1)
     uint32_t n_begin_open_threads;
     uint32_t n_end_open_threads;
 
@@ -54,6 +55,7 @@ typedef struct OPEN_CLOSE_THREADS_TAG
     THREAD_HANDLE endCloseThreads[N_MAX_THREADS];
     volatile_atomic int32_t n_begin_close_grants;
     volatile_atomic int32_t n_begin_close_refuses;
+    volatile_atomic int32_t begin_close_pending; // Track begin_close for when end_close should be called (0 or 1)
     uint32_t n_begin_close_threads;
     uint32_t n_end_close_threads;
 
@@ -61,13 +63,24 @@ typedef struct OPEN_CLOSE_THREADS_TAG
     THREAD_HANDLE endBarrierThreads[N_MAX_THREADS];
     volatile_atomic int32_t n_begin_barrier_grants;
     volatile_atomic int32_t n_begin_barrier_refuses;
+    volatile_atomic int32_t begin_barrier_pending; // Track begin_barrier for when end_barrier should be called (0 or 1)
     uint32_t n_begin_barrier_threads;
     uint32_t n_end_barrier_threads;
 
-    THREAD_HANDLE beginThreads[N_MAX_THREADS];
+    THREAD_HANDLE beginAndEndThreads[N_MAX_THREADS];
     volatile_atomic int32_t n_begin_grants;
     volatile_atomic int32_t n_begin_refuses;
-    uint32_t n_begin_threads;
+    uint32_t n_begin_and_end_threads;
+
+    THREAD_HANDLE beginExecThreads[N_MAX_THREADS];
+    THREAD_HANDLE endExecThreads[N_MAX_THREADS];
+    volatile_atomic int32_t begin_exec_pending; // Track begin_exec for when end_exec should be called (0 to N)
+    uint32_t n_begin_exec_threads;
+    uint32_t n_end_exec_threads;
+
+    THREAD_HANDLE faultThreads[N_MAX_THREADS];
+    volatile_atomic int32_t n_faults;
+    uint32_t n_fault_threads;
 
     volatile_atomic int32_t threadsShouldFinish; /*this test is time bound*/
 } OPEN_CLOSE_THREADS;
@@ -82,6 +95,7 @@ static int callsBeginOpen(
     {
         if (sm_open_begin(data->sm) == SM_EXEC_GRANTED)
         {
+            (void)interlocked_increment(&data->begin_open_pending); // now make sure end_open is called
             (void)interlocked_increment(&data->n_begin_open_grants);
         }
         else
@@ -95,19 +109,18 @@ static int callsBeginOpen(
 
 static void createBeginOpenThreads(OPEN_CLOSE_THREADS* data)
 {
-    uint32_t iBeginOpen;
-    for (iBeginOpen = 0; iBeginOpen < data->n_begin_open_threads; iBeginOpen++)
+    for (uint32_t i = 0; i < data->n_begin_open_threads; i++)
     {
-        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->beginOpenThreads[iBeginOpen], callsBeginOpen, data));
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->beginOpenThreads[i], callsBeginOpen, data));
     }
 }
 
 static void waitAndDestroyBeginOpenThreads(OPEN_CLOSE_THREADS* data)
 {
-    for (uint32_t iBeginOpen = 0; iBeginOpen < data->n_begin_open_threads; iBeginOpen++)
+    for (uint32_t i = 0; i < data->n_begin_open_threads; i++)
     {
         int dont_care;
-        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->beginOpenThreads[iBeginOpen], &dont_care));
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->beginOpenThreads[i], &dont_care));
     }
 }
 
@@ -119,7 +132,22 @@ static int callsEndOpen(
 
     while (interlocked_add(&data->threadsShouldFinish, 0) == 0)
     {
-        sm_open_end(data->sm, (rand()%2==0));
+        int32_t pending = interlocked_add(&data->begin_open_pending, 0);
+        if (pending > 0)
+        {
+            if (interlocked_compare_exchange(&data->begin_open_pending, pending - 1, pending) == pending)
+            {
+                sm_open_end(data->sm, (rand() % 2 == 0));
+            }
+            else
+            {
+                // something else decremented...
+            }
+        }
+        else
+        {
+            // No sm_begin_open was called, nothing to do...
+        }
         ThreadAPI_Sleep(0);
     }
     return 0;
@@ -142,14 +170,18 @@ static void waitAndDestroyEndOpenThreads(OPEN_CLOSE_THREADS* data)
     /*note: the loop below does not guarantee that any one of spawned threads calls it*/
     /*here's how that might not happen: all callsEndOpen threads are Sleeping. Then they (all of them) wake up, they evaluate the condition "threadsShouldFinish", find it true, and exit.*/
     /*thus leaving the open_end not called*/
-    for (uint32_t iEndOpen = 0; iEndOpen < data->n_end_open_threads; iEndOpen++)
+    for (uint32_t i = 0; i < data->n_end_open_threads; i++)
     {
         int dont_care;
-        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->endOpenThreads[iEndOpen], &dont_care));
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->endOpenThreads[i], &dont_care));
     }
-    /*and in case the above comment happens and there's 1 sm_open_begin that is not matched by 1 sm_open_end we will call it here. If there isn't, still call it - it is harmless at this moment.*/
-    sm_open_end(data->sm, true);
-    
+
+    // We know precisely whether end needs to be called one more time now:
+    if (interlocked_add(&data->begin_open_pending, 0) > 0)
+    {
+        sm_open_end(data->sm, false);
+        (void)interlocked_decrement(&data->begin_open_pending);
+    }
 }
 
 
@@ -163,6 +195,7 @@ static int callsBeginClose(
     {
         if (sm_close_begin(data->sm) == SM_EXEC_GRANTED)
         {
+            (void)interlocked_increment(&data->begin_close_pending); // now make sure end_open is called
             (void)interlocked_increment(&data->n_begin_close_grants);
         }
         else
@@ -177,19 +210,18 @@ static int callsBeginClose(
 
 static void createBeginCloseThreads(OPEN_CLOSE_THREADS* data)
 {
-    uint32_t iBeginClose;
-    for (iBeginClose = 0; iBeginClose < data->n_begin_close_threads; iBeginClose++)
+    for (uint32_t i = 0; i < data->n_begin_close_threads; i++)
     {
-        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->beginCloseThreads[iBeginClose], callsBeginClose, data));
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->beginCloseThreads[i], callsBeginClose, data));
     }
 }
 
 static void waitAndDestroyBeginCloseThreads(OPEN_CLOSE_THREADS* data)
 {
-    for (uint32_t iBeginClose = 0; iBeginClose < data->n_begin_close_threads; iBeginClose++)
+    for (uint32_t i = 0; i < data->n_begin_close_threads; i++)
     {
         int dont_care;
-        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->beginCloseThreads[iBeginClose], &dont_care));
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->beginCloseThreads[i], &dont_care));
     }
 }
 
@@ -201,7 +233,22 @@ static int callsEndClose(
 
     while (interlocked_add(&data->threadsShouldFinish, 0) == 0)
     {
-        sm_close_end(data->sm); /*might as well fail*/
+        int32_t pending = interlocked_add(&data->begin_close_pending, 0);
+        if (pending > 0)
+        {
+            if (interlocked_compare_exchange(&data->begin_close_pending, pending - 1, pending) == pending)
+            {
+                sm_close_end(data->sm);
+            }
+            else
+            {
+                // something else decremented...
+            }
+        }
+        else
+        {
+            // No sm_begin_close was called, nothing to do...
+        }
         ThreadAPI_Sleep(0);
     }
     return 0;
@@ -209,10 +256,9 @@ static int callsEndClose(
 
 static void createEndCloseThreads(OPEN_CLOSE_THREADS* data)
 {
-    uint32_t iEndClose;
-    for (iEndClose = 0; iEndClose < data->n_end_close_threads; iEndClose++)
+    for (uint32_t i = 0; i < data->n_end_close_threads; i++)
     {
-        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->endCloseThreads[iEndClose], callsEndClose, data));
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->endCloseThreads[i], callsEndClose, data));
     }
 }
 
@@ -224,13 +270,18 @@ static void waitAndDestroyEndCloseThreads(OPEN_CLOSE_THREADS* data)
     /*note: the loop below does not guarantee that any one of spawned threads calls it*/
     /*here's how that might not happen: all callsEndClose threads are Sleeping. Then they (all of them) wake up, they evaluate the condition "threadsShouldFinish", find it true, and exit.*/
     /*thus leaving the sm_close_end not called*/
-    for (uint32_t iEndClose = 0; iEndClose < data->n_end_close_threads; iEndClose++)
+    for (uint32_t i = 0; i < data->n_end_close_threads; i++)
     {
         int dont_care;
-        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->endCloseThreads[iEndClose], &dont_care));
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->endCloseThreads[i], &dont_care));
     }
-    /*and in case the above comment happens and there's 1 sm_close_begin that is not matched by 1 sm_close_end we will call it here. If there isn't, still call it - it is harmless at this moment.*/
-    sm_close_end(data->sm);
+
+    // We know precisely whether end needs to be called one more time now:
+    if (interlocked_add(&data->begin_close_pending, 0) > 0)
+    {
+        sm_close_end(data->sm);
+        (void)interlocked_decrement(&data->begin_close_pending);
+    }
 }
 
 static int callsBeginBarrier(
@@ -243,6 +294,7 @@ static int callsBeginBarrier(
     {
         if (sm_barrier_begin(data->sm) == SM_EXEC_GRANTED)
         {
+            (void)interlocked_increment(&data->begin_barrier_pending); // now make sure end_barrier is called
             (void)interlocked_increment(&data->n_begin_barrier_grants);
         }
         else
@@ -256,19 +308,18 @@ static int callsBeginBarrier(
 
 static void createBeginBarrierThreads(OPEN_CLOSE_THREADS* data)
 {
-    uint32_t iBeginBarrier;
-    for (iBeginBarrier = 0; iBeginBarrier < data->n_begin_barrier_threads; iBeginBarrier++)
+    for (uint32_t i = 0; i < data->n_begin_barrier_threads; i++)
     {
-        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->beginBarrierThreads[iBeginBarrier], callsBeginBarrier, data));
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->beginBarrierThreads[i], callsBeginBarrier, data));
     }
 }
 
 static void waitAndDestroyBeginBarrierThreads(OPEN_CLOSE_THREADS* data)
 {
-    for (uint32_t iBeginBarrier = 0; iBeginBarrier < data->n_begin_barrier_threads; iBeginBarrier++)
+    for (uint32_t i = 0; i < data->n_begin_barrier_threads; i++)
     {
         int dont_care;
-        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->beginBarrierThreads[iBeginBarrier], &dont_care));
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->beginBarrierThreads[i], &dont_care));
     }
 }
 
@@ -280,7 +331,22 @@ static int callsEndBarrier(
 
     while (interlocked_add(&data->threadsShouldFinish, 0) == 0)
     {
-        sm_barrier_end(data->sm); /*might as well fail*/
+        int32_t pending = interlocked_add(&data->begin_barrier_pending, 0);
+        if (pending > 0)
+        {
+            if (interlocked_compare_exchange(&data->begin_barrier_pending, pending - 1, pending) == pending)
+            {
+                sm_barrier_end(data->sm);
+            }
+            else
+            {
+                // something else decremented...
+            }
+        }
+        else
+        {
+            // No sm_begin_close was called, nothing to do...
+        }
         ThreadAPI_Sleep(0);
     }
     return 0;
@@ -288,10 +354,9 @@ static int callsEndBarrier(
 
 static void createEndBarrierThreads(OPEN_CLOSE_THREADS* data)
 {
-    uint32_t iEndBarrier;
-    for (iEndBarrier = 0; iEndBarrier < data->n_end_barrier_threads; iEndBarrier++)
+    for (uint32_t i = 0; i < data->n_end_barrier_threads; i++)
     {
-        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->endBarrierThreads[iEndBarrier], callsEndBarrier, data));
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->endBarrierThreads[i], callsEndBarrier, data));
     }
 }
 
@@ -303,13 +368,119 @@ static void waitAndDestroyEndBarrierThreads(OPEN_CLOSE_THREADS* data)
     /*note: the loop below does not guarantee that any one of spawned threads calls it*/
     /*here's how that might not happen: all callsEndBarrier threads are Sleeping. Then they (all of them) wake up, they evaluate the condition "threadsShouldFinish", find it true, and exit.*/
     /*thus leaving the sm_barrier_end not called*/
-    for (uint32_t iEndBarrier = 0; iEndBarrier < data->n_end_barrier_threads; iEndBarrier++)
+    for (uint32_t i = 0; i < data->n_end_barrier_threads; i++)
     {
         int dont_care;
-        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->endBarrierThreads[iEndBarrier], &dont_care));
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->endBarrierThreads[i], &dont_care));
     }
-    /*and in case the above comment happens and there's 1 sm_barrier_begin that is not matched by 1 sm_barrier_end we will call it here. If there isn't, still call it - it is harmless at this moment.*/
-    sm_barrier_end(data->sm); /*might as well fail*/
+
+    // We know precisely whether end needs to be called one more time now:
+    if (interlocked_add(&data->begin_barrier_pending, 0) > 0)
+    {
+        sm_barrier_end(data->sm);
+        (void)interlocked_decrement(&data->begin_barrier_pending);
+    }
+}
+
+static int callsBeginExec(
+    void* arg
+)
+{
+    OPEN_CLOSE_THREADS* data = (OPEN_CLOSE_THREADS*)arg;
+
+    while (interlocked_add(&data->threadsShouldFinish, 0) == 0)
+    {
+        if (sm_exec_begin(data->sm) == SM_EXEC_GRANTED)
+        {
+            int32_t pending_execs = interlocked_increment(&data->begin_exec_pending); // now make sure end_exec is called
+
+            // If this were to overflow, the test would probably fail somewhere
+            // In order to avoid extra logic in these threads, we will just ignore that but fail the test when it happens
+            // It seems unlikely we can hit this in the short time the test runs for, but we can fix it if that assumption is bad
+            ASSERT_IS_TRUE(pending_execs > 0, "The begin_exec_pending overflowed, likely test needs to be fixed!");
+
+            (void)interlocked_increment(&data->n_begin_grants);
+
+            uint32_t pretend_to_do_something_time_in_ms = rand() % 10;
+            ThreadAPI_Sleep(pretend_to_do_something_time_in_ms);
+        }
+        else
+        {
+            (void)interlocked_increment(&data->n_begin_refuses);
+            ThreadAPI_Sleep(0);
+        }
+    }
+    return 0;
+}
+
+static void createBeginExecThreads(OPEN_CLOSE_THREADS* data)
+{
+    for (uint32_t i = 0; i < data->n_begin_exec_threads; i++)
+    {
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->beginExecThreads[i], callsBeginExec, data));
+    }
+}
+
+static void waitAndDestroyBeginExecThreads(OPEN_CLOSE_THREADS* data)
+{
+    for (uint32_t i = 0; i < data->n_begin_exec_threads; i++)
+    {
+        int dont_care;
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->beginExecThreads[i], &dont_care));
+    }
+}
+
+static int callsEndExec(
+    void* arg
+)
+{
+    OPEN_CLOSE_THREADS* data = (OPEN_CLOSE_THREADS*)arg;
+
+    while (interlocked_add(&data->threadsShouldFinish, 0) == 0)
+    {
+        int32_t pending = interlocked_add(&data->begin_exec_pending, 0);
+        if (pending > 0)
+        {
+            if (interlocked_compare_exchange(&data->begin_exec_pending, pending - 1, pending) == pending)
+            {
+                sm_exec_end(data->sm);
+            }
+            else
+            {
+                // something else decremented...
+            }
+        }
+        else
+        {
+            // No sm_begin_close was called, nothing to do...
+        }
+        ThreadAPI_Sleep(0);
+    }
+    return 0;
+}
+
+static void createEndExecThreads(OPEN_CLOSE_THREADS* data)
+{
+    for (uint32_t i = 0; i < data->n_end_exec_threads; i++)
+    {
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->endExecThreads[i], callsEndExec, data));
+    }
+}
+
+static void waitAndDestroyEndExecThreads(OPEN_CLOSE_THREADS* data)
+{
+    for (uint32_t i = 0; i < data->n_end_exec_threads; i++)
+    {
+        int dont_care;
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->endExecThreads[i], &dont_care));
+    }
+
+    // We know precisely whether end needs to be called more (could be multiple times)
+    while (interlocked_add(&data->begin_exec_pending, 0) > 0)
+    {
+        sm_exec_end(data->sm);
+        (void)interlocked_decrement(&data->begin_exec_pending);
+    }
 }
 
 static int callsBeginAndEnd(
@@ -337,19 +508,50 @@ static int callsBeginAndEnd(
 
 static void createBeginAndEndThreads(OPEN_CLOSE_THREADS* data)
 {
-    uint32_t iBegin;
-    for (iBegin = 0; iBegin < data->n_begin_threads; iBegin++)
+    for (uint32_t i = 0; i < data->n_begin_and_end_threads; i++)
     {
-        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->beginThreads[iBegin], callsBeginAndEnd, data));
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->beginAndEndThreads[i], callsBeginAndEnd, data));
     }
 }
 
 static void waitAndDestroyBeginAndEndThreads(OPEN_CLOSE_THREADS* data)
 {
-    for (uint32_t iBegin = 0; iBegin < data->n_begin_threads; iBegin++)
+    for (uint32_t i = 0; i < data->n_begin_and_end_threads; i++)
     {
         int dont_care;
-        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->beginThreads[iBegin], &dont_care));
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->beginAndEndThreads[i], &dont_care));
+    }
+}
+
+static int callsFault(
+    void* arg
+)
+{
+    OPEN_CLOSE_THREADS* data = (OPEN_CLOSE_THREADS*)arg;
+
+    while (interlocked_add(&data->threadsShouldFinish, 0) == 0)
+    {
+        uint32_t time_before_next_fault = rand() % 300;
+        ThreadAPI_Sleep(time_before_next_fault);
+        sm_fault(data->sm);
+    }
+    return 0;
+}
+
+static void createFaultThreads(OPEN_CLOSE_THREADS* data)
+{
+    for (uint32_t i = 0; i < data->n_fault_threads; i++)
+    {
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&data->faultThreads[i], callsFault, data));
+    }
+}
+
+static void waitAndDestroyFaultThreads(OPEN_CLOSE_THREADS* data)
+{
+    for (uint32_t i = 0; i < data->n_fault_threads; i++)
+    {
+        int dont_care;
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(data->faultThreads[i], &dont_care));
     }
 }
 
@@ -496,19 +698,26 @@ static uint32_t numberOfProcessors;
 SM_OPEN_BEGIN,              \
 SM_CLOSE_BEGIN,             \
 SM_EXEC_BEGIN,              \
-SM_BARRIER_BEGIN            \
+SM_BARRIER_BEGIN,           \
+SM_FAULT                    \
 
-MU_DEFINE_ENUM(SM_APIS, SM_APIS_VALUES)
-MU_DEFINE_ENUM_STRINGS(SM_APIS, SM_APIS_VALUES)
+MU_DEFINE_ENUM_WITHOUT_INVALID(SM_APIS, SM_APIS_VALUES)
+MU_DEFINE_ENUM_STRINGS_WITHOUT_INVALID(SM_APIS, SM_APIS_VALUES)
 
-#define SM_STATES_VALUES             \
-SM_CREATED,                          \
-SM_OPENING,                          \
-SM_OPENED,                           \
-SM_OPENED_DRAINING_TO_BARRIER,       \
-SM_OPENED_DRAINING_TO_CLOSE,         \
-SM_OPENED_BARRIER,                   \
-SM_CLOSING                           \
+#define SM_STATES_VALUES               \
+SM_CREATED,                            \
+SM_OPENING,                            \
+SM_OPENING_FAULTED,                    \
+SM_OPENED,                             \
+SM_OPENED_FAULTED,                     \
+SM_OPENED_DRAINING_TO_BARRIER,         \
+SM_OPENED_DRAINING_TO_BARRIER_FAULTED, \
+SM_OPENED_DRAINING_TO_CLOSE,           \
+SM_OPENED_DRAINING_TO_CLOSE_FAULTED,   \
+SM_OPENED_BARRIER,                     \
+SM_OPENED_BARRIER_FAULTED,             \
+SM_CLOSING,                            \
+SM_CLOSING_FAULTED                     \
 
 
 MU_DEFINE_ENUM(SM_STATES, SM_STATES_VALUES)
@@ -566,8 +775,16 @@ TEST_FUNCTION(sm_chaos)
         data->n_end_close_threads = nthreads;
         data->n_begin_barrier_threads = nthreads;
         data->n_end_barrier_threads = nthreads;
-        data->n_begin_threads = nthreads;
-        
+        data->n_begin_and_end_threads = nthreads;
+        data->n_begin_exec_threads = nthreads;
+        data->n_end_exec_threads = nthreads;
+        data->n_fault_threads = nthreads;
+
+        (void)interlocked_exchange(&data->begin_open_pending, 0);
+        (void)interlocked_exchange(&data->begin_close_pending, 0);
+        (void)interlocked_exchange(&data->begin_barrier_pending, 0);
+        (void)interlocked_exchange(&data->begin_exec_pending, 0);
+
         (void)interlocked_exchange(&data->threadsShouldFinish, 0);
         (void)interlocked_exchange(&data->n_begin_open_grants, 0);
         (void)interlocked_exchange(&data->n_begin_open_refuses, 0);
@@ -577,6 +794,7 @@ TEST_FUNCTION(sm_chaos)
         (void)interlocked_exchange(&data->n_begin_barrier_refuses, 0);
         (void)interlocked_exchange(&data->n_begin_grants, 0);
         (void)interlocked_exchange(&data->n_begin_refuses, 0);
+        (void)interlocked_exchange(&data->n_faults, 0);
 
         createBeginOpenThreads(data);
         createEndOpenThreads(data);
@@ -585,15 +803,18 @@ TEST_FUNCTION(sm_chaos)
         createBeginBarrierThreads(data);
         createEndBarrierThreads(data);
         createBeginAndEndThreads(data);
+        createBeginExecThreads(data);
+        createEndExecThreads(data);
+        createFaultThreads(data);
 
         ThreadAPI_Sleep(1000);
         uint32_t counterSleep = 1;
         int32_t n_begin_open_grants_local;
         int32_t n_begin_grants_local;
         while (
-            (n_begin_open_grants_local=interlocked_add(&data->n_begin_open_grants, 0)), 
+            (n_begin_open_grants_local = interlocked_add(&data->n_begin_open_grants, 0)),
             (n_begin_grants_local = interlocked_add(&data->n_begin_grants, 0)),
-            ((n_begin_open_grants_local==0) ||(n_begin_grants_local==0))
+            ((n_begin_open_grants_local==0) || (n_begin_grants_local==0))
             )
         {
             toBeRestored(AZ_LOG_INFO, __FILE__, FUNC_NAME, __LINE__, 0, "Slept %" PRIu32 " ms, no sign of n_begin_open_grants=%" PRId32 ", n_begin_grants=%" PRId32 "\n", counterSleep * 1000, n_begin_open_grants_local, n_begin_grants_local);
@@ -603,24 +824,29 @@ TEST_FUNCTION(sm_chaos)
 
         (void)interlocked_exchange(&data->threadsShouldFinish, 1);
 
+        waitAndDestroyBeginExecThreads(data);
+        waitAndDestroyEndExecThreads(data);
         waitAndDestroyBeginAndEndThreads(data);
 
         waitAndDestroyBeginBarrierThreads(data);
         waitAndDestroyEndBarrierThreads(data);
-        
+
+        waitAndDestroyFaultThreads(data);
+
         waitAndDestroyBeginCloseThreads(data);
         waitAndDestroyEndCloseThreads(data);
-        
+
         waitAndDestroyBeginOpenThreads(data);
         waitAndDestroyEndOpenThreads(data);
 
         /*just in case anything needs to close*/
 
         toBeRestored(AZ_LOG_INFO, __FILE__, FUNC_NAME, __LINE__, 0, "nthreads=%" PRIu32
-            ", n_begin_open_grants=%" PRIu32 ", n_begin_open_refuses=%" PRIu32 
-            ", n_begin_close_grants=%" PRIu32 ", n_begin_close_refuses=%" PRIu32 
+            ", n_begin_open_grants=%" PRIu32 ", n_begin_open_refuses=%" PRIu32
+            ", n_begin_close_grants=%" PRIu32 ", n_begin_close_refuses=%" PRIu32
             ", n_begin_barrier_grants=%" PRIu32 ", n_begin_barrier_refuses=%" PRIu32
             ", n_begin_grants=%" PRIu32 ", n_begin_refuses=%" PRIu32
+            ", n_faults=%" PRIu32
             "\n",
             nthreads,
             interlocked_add(&data->n_begin_open_grants, 0),
@@ -630,7 +856,8 @@ TEST_FUNCTION(sm_chaos)
             interlocked_add(&data->n_begin_barrier_grants, 0),
             interlocked_add(&data->n_begin_barrier_refuses, 0),
             interlocked_add(&data->n_begin_grants, 0),
-            interlocked_add(&data->n_begin_refuses, 0)
+            interlocked_add(&data->n_begin_refuses, 0),
+            interlocked_add(&data->n_faults, 0)
         );
 
         ASSERT_IS_TRUE(interlocked_add(&data->n_begin_open_grants, 0) >= 1);
@@ -715,7 +942,7 @@ TEST_FUNCTION(sm_does_not_block)
             verify(data);
 
             toBeRestored(AZ_LOG_INFO, __FILE__, FUNC_NAME, __LINE__, 0, "Info: took %f ms, non_barrier_grants=%" PRId32 ", non_barrier_refusals=%" PRId64 " barrier_grants=%" PRId32 ", barrier_refusals=%" PRId64 "\n", timer_global_get_elapsed_ms() - data->startTimems,
-                interlocked_add(&non_barrier_grants, 0), 
+                interlocked_add(&non_barrier_grants, 0),
                 interlocked_add_64(&non_barrier_refusals, 0),
                 interlocked_add(&barrier_grants, 0),
                 interlocked_add_64(&barrier_refusals, 0));
@@ -738,17 +965,24 @@ TEST_FUNCTION(sm_does_not_block)
 /*these are states
 SM_CREATED	SM_CREATED(1)	SM_STATE_TAG
 SM_OPENING	SM_OPENING(2)	SM_STATE_TAG
-SM_OPENED	SM_OPENED(3)	SM_STATE_TAG
-SM_OPENED_DRAINING_TO_BARRIER	SM_OPENED_DRAINING_TO_BARRIER(4)	SM_STATE_TAG
-SM_OPENED_DRAINING_TO_CLOSE	SM_OPENED_DRAINING_TO_CLOSE(5)	SM_STATE_TAG
-SM_OPENED_BARRIER	SM_OPENED_BARRIER(6)	SM_STATE_TAG
-SM_CLOSING	SM_CLOSING(7)	SM_STATE_TAG
+SM_OPENING_FAULTED	SM_OPENING_FAULTED(3)	SM_STATE_TAG
+SM_OPENED	SM_OPENED(4)	SM_STATE_TAG
+SM_OPENED_FAULTED	SM_OPENED_FAULTED(5)	SM_STATE_TAG
+SM_OPENED_DRAINING_TO_BARRIER	SM_OPENED_DRAINING_TO_BARRIER(6)	SM_STATE_TAG
+SM_OPENED_DRAINING_TO_BARRIER_FAULTED	SM_OPENED_DRAINING_TO_BARRIER_FAULTED(7)	SM_STATE_TAG
+SM_OPENED_DRAINING_TO_CLOSE	SM_OPENED_DRAINING_TO_CLOSE(8)	SM_STATE_TAG
+SM_OPENED_DRAINING_TO_CLOSE_FAULTED	SM_OPENED_DRAINING_TO_CLOSE_FAULTED(9)	SM_STATE_TAG
+SM_OPENED_BARRIER	SM_OPENED_BARRIER(10)	SM_STATE_TAG
+SM_OPENED_BARRIER_FAULTED	SM_OPENED_BARRIER_FAULTED(11)	SM_STATE_TAG
+SM_CLOSING	SM_CLOSING(12)	SM_STATE_TAG
+SM_CLOSING_FAULTED	SM_CLOSING_FAULTED(13)	SM_STATE_TAG
 
 these are APIs:
 sm_open_begin
 sm_close_begin
 sm_exec_begin
 sm_barrier_begin
+sm_fault
 */
 
 #define THREAD_DELAY 500
@@ -771,8 +1005,7 @@ typedef struct SM_GO_TO_STATE_TAG
     volatile_atomic int32_t targetStateAPICalledInNextLine; /*event set when the target state will be switched in the next line of code. That call might or not return. For example when in the case of wanting to reach the state of SM_OPENED_DRAINING_TO_BARRIER. The call doesn't return until all the sm_exec_end have been called*/
 
     volatile_atomic int32_t targetAPICalledInNextLine; /*event set just before calling the API in a specific state. This is needed because some of the APIs are blocking (such as calling sm_close_begin when a barrier is executing)*/
-}SM_GO_TO_STATE; 
-
+}SM_GO_TO_STATE;
 
 static int switchesToState(
     void* arg
@@ -794,10 +1027,23 @@ static int switchesToState(
             ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_open_begin(goToState->sm));
             break;
         }
+        case SM_OPENING_FAULTED:
+        {
+            ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_open_begin(goToState->sm));
+            sm_fault(goToState->sm);
+            break;
+        }
         case SM_OPENED:
         {
             ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_open_begin(goToState->sm));
             sm_open_end(goToState->sm, true);
+            break;
+        }
+        case SM_OPENED_FAULTED:
+        {
+            ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_open_begin(goToState->sm));
+            sm_open_end(goToState->sm, true);
+            sm_fault(goToState->sm);
             break;
         }
         case SM_OPENED_DRAINING_TO_BARRIER:
@@ -810,7 +1056,19 @@ static int switchesToState(
             ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_barrier_begin(goToState->sm)); /*switches to draining mode - and stays there, because sm_exec_end was not called yet */
             LogInfo("time[s]=%.2f, switches state thread: returning from sm_barrier_begin(goToState->sm)", (timer_global_get_elapsed_ms() - timeSinceTestFunctionStartMs) / 1000);
             break;
+        }
+        case SM_OPENED_DRAINING_TO_BARRIER_FAULTED:
+        {
+            ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_open_begin(goToState->sm));
+            sm_open_end(goToState->sm, true);
 
+            ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_exec_begin(goToState->sm));
+
+            ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_barrier_begin(goToState->sm)); /*switches to draining mode - and stays there, because sm_exec_end was not called yet */
+
+            sm_fault(goToState->sm);
+            LogInfo("time[s]=%.2f, switches state thread: returning from sm_barrier_begin(goToState->sm)", (timer_global_get_elapsed_ms() - timeSinceTestFunctionStartMs) / 1000);
+            break;
         }
         case SM_OPENED_DRAINING_TO_CLOSE:
         {
@@ -824,6 +1082,20 @@ static int switchesToState(
 
             break;
         }
+        case SM_OPENED_DRAINING_TO_CLOSE_FAULTED:
+        {
+            ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_open_begin(goToState->sm));
+            sm_open_end(goToState->sm, true);
+
+            ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_exec_begin(goToState->sm));
+
+            ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_close_begin(goToState->sm)); /*switches to draining mode*/
+
+            sm_fault(goToState->sm);
+            LogInfo("time[s]=%.2f, switchesToState thread: returning from sm_close_begin(goToState->sm)", (timer_global_get_elapsed_ms() - timeSinceTestFunctionStartMs) / 1000);
+
+            break;
+        }
         case SM_OPENED_BARRIER:
         {
             ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_open_begin(goToState->sm));
@@ -832,12 +1104,33 @@ static int switchesToState(
             ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_barrier_begin(goToState->sm));
             break;
         }
+        case SM_OPENED_BARRIER_FAULTED:
+        {
+            ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_open_begin(goToState->sm));
+            sm_open_end(goToState->sm, true);
+
+            ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_barrier_begin(goToState->sm));
+
+            sm_fault(goToState->sm);
+            break;
+        }
         case SM_CLOSING:
         {
             ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_open_begin(goToState->sm));
             sm_open_end(goToState->sm, true);
 
             ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_close_begin(goToState->sm));
+            LogInfo("time[s]=%.2f, switchesToState thread: returning from sm_close_begin(goToState->sm)", (timer_global_get_elapsed_ms() - timeSinceTestFunctionStartMs) / 1000);
+            break;
+        }
+        case SM_CLOSING_FAULTED:
+        {
+            ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_open_begin(goToState->sm));
+            sm_open_end(goToState->sm, true);
+
+            ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_close_begin(goToState->sm));
+
+            sm_fault(goToState->sm);
             LogInfo("time[s]=%.2f, switchesToState thread: returning from sm_close_begin(goToState->sm)", (timer_global_get_elapsed_ms() - timeSinceTestFunctionStartMs) / 1000);
             break;
         }
@@ -865,7 +1158,7 @@ static int switchesFromStateToCreated(
 {
     SM_GO_TO_STATE* goToState = (SM_GO_TO_STATE*)arg;
 
-    /*waits on 1 handles that says the API is about to be called. It waits 1 second then it resumes executiong */
+    /*waits on 1 handles that says the API is about to be called. It waits 500 ms then it resumes execution */
 
     ASSERT_ARE_EQUAL(INTERLOCKED_HL_RESULT, INTERLOCKED_HL_OK, InterlockedHL_WaitForValue(&goToState->targetAPICalledInNextLine, 1, UINT32_MAX));
 
@@ -880,6 +1173,7 @@ static int switchesFromStateToCreated(
             break;
         }
         case SM_OPENING:
+        case SM_OPENING_FAULTED:
         {
             sm_open_end(goToState->sm, true);
             ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_close_begin(goToState->sm));
@@ -887,15 +1181,21 @@ static int switchesFromStateToCreated(
             break;
         }
         case SM_OPENED:
+        case SM_OPENED_FAULTED:
         {
             if (sm_close_begin(goToState->sm) == SM_EXEC_GRANTED)
             {
                 sm_close_end(goToState->sm);
             }
-            
+            else
+            {
+                ASSERT_FAIL("Why?");
+            }
+
             break;
         }
         case SM_OPENED_DRAINING_TO_BARRIER:
+        case SM_OPENED_DRAINING_TO_BARRIER_FAULTED:
         {
             sm_exec_end(goToState->sm);
             /*calling sm_exec_end will unblock sm_barrier_begin from the switchesToThread (if any)*/
@@ -911,18 +1211,24 @@ static int switchesFromStateToCreated(
             {
                 sm_close_end(goToState->sm);
             }
+            else
+            {
+                ASSERT_FAIL("Why?");
+            }
             break;
 
         }
         case SM_OPENED_DRAINING_TO_CLOSE:
+        case SM_OPENED_DRAINING_TO_CLOSE_FAULTED:
         {
             sm_exec_end(goToState->sm);
             /*unblocks sm_close_begin in the switchesState thread*/
-            
+
             sm_close_end(goToState->sm);
             break;
         }
         case SM_OPENED_BARRIER:
+        case SM_OPENED_BARRIER_FAULTED:
         {
             sm_barrier_end(goToState->sm);
 
@@ -933,6 +1239,7 @@ static int switchesFromStateToCreated(
             break;
         }
         case SM_CLOSING:
+        case SM_CLOSING_FAULTED:
         {
             sm_exec_end(goToState->sm);
             ThreadAPI_Sleep(THREAD_DELAY);
@@ -961,6 +1268,7 @@ static void sm_switches_from_state_to_created(SM_GO_TO_STATE* goToState)
 
 /*Tests_SRS_SM_02_050: [ If the state is SM_OPENED_BARRIER then sm_close_begin shall re-evaluate the state. ]*/
 /*Tests_SRS_SM_02_051: [ If the state is SM_OPENED_DRAINING_TO_BARRIER then sm_close_begin shall re-evaluate the state. ]*/
+/*Tests_SRS_SM_42_009: [ While the state changes before setting the bit then sm_fault shall re-evaluate the state. ]*/
 
 /*tests different expected returns from different states of SM*/
 /*at time=0                     a thread is started that switched state to the desired state to execute some API. This thread might block there. For example when the "to" state is SM_OPENED_DRAINING_TO_BARRIER. */
@@ -972,19 +1280,25 @@ TEST_FUNCTION(STATE_and_API)
 {
     SM_RESULT_AND_NEXT_STATE_AFTER_API_CALL expected[][4]=
     {
-                                                /*sm_open_begin*/                                    /*sm_close_begin*/                              /*sm_exec_begin*/                                    /*sm_barrier_begin*/
-        /*SM_CREATED*/                      {   {SM_EXEC_GRANTED, SM_OPENING},                       {SM_EXEC_REFUSED, SM_CREATED},                  {SM_EXEC_REFUSED, SM_CREATED},                       {SM_EXEC_REFUSED, SM_CREATED}},
-        /*SM_OPENING*/                      {   {SM_EXEC_REFUSED, SM_OPENING},                       {SM_EXEC_REFUSED, SM_OPENING},                  {SM_EXEC_REFUSED, SM_OPENING},                       {SM_EXEC_REFUSED, SM_OPENING}},
-        /*SM_OPENED*/                       {   {SM_EXEC_REFUSED, SM_OPENED},                        {SM_EXEC_GRANTED, SM_CLOSING},                  {SM_EXEC_GRANTED, SM_OPENED},                        {SM_EXEC_GRANTED, SM_OPENED_BARRIER}},
-        /*SM_OPENED_DRAINING_TO_BARRIER*/   {   {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_BARRIER},    {SM_EXEC_GRANTED, SM_CLOSING},                  {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_BARRIER},    {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_BARRIER}},
-        /*SM_OPENED_DRAINING_TO_CLOSE*/     {   {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_CLOSE},      {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_CLOSE}, {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_CLOSE},      {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_CLOSE}},
-        /*SM_OPENED_BARRIER*/               {   {SM_EXEC_REFUSED, SM_OPENED_BARRIER},                {SM_EXEC_GRANTED, SM_CLOSING},                  {SM_EXEC_REFUSED, SM_OPENED_BARRIER},                {SM_EXEC_REFUSED, SM_OPENED_BARRIER}},
-        /*SM_CLOSING*/                      {   {SM_EXEC_REFUSED, SM_CLOSING},                       {SM_EXEC_REFUSED, SM_CLOSING},                  {SM_EXEC_REFUSED, SM_CLOSING},                       {SM_EXEC_REFUSED, SM_CLOSING}}
+                                                      /*sm_open_begin*/                                         /*sm_close_begin*/                                      /*sm_exec_begin*/                                         /*sm_barrier_begin*/
+        /*SM_CREATED*/                            {   {SM_EXEC_GRANTED, SM_OPENING},                            {SM_EXEC_REFUSED, SM_CREATED},                          {SM_EXEC_REFUSED, SM_CREATED},                            {SM_EXEC_REFUSED, SM_CREATED}},
+        /*SM_OPENING*/                            {   {SM_EXEC_REFUSED, SM_OPENING},                            {SM_EXEC_REFUSED, SM_OPENING},                          {SM_EXEC_REFUSED, SM_OPENING},                            {SM_EXEC_REFUSED, SM_OPENING}},
+        /*SM_OPENING_FAULTED*/                    {   {SM_EXEC_REFUSED, SM_OPENING_FAULTED},                    {SM_EXEC_REFUSED, SM_OPENING_FAULTED},                  {SM_EXEC_REFUSED, SM_OPENING_FAULTED},                    {SM_EXEC_REFUSED, SM_OPENING_FAULTED}},
+        /*SM_OPENED*/                             {   {SM_EXEC_REFUSED, SM_OPENED},                             {SM_EXEC_GRANTED, SM_CLOSING},                          {SM_EXEC_GRANTED, SM_OPENED},                             {SM_EXEC_GRANTED, SM_OPENED_BARRIER}},
+        /*SM_OPENED_FAULTED*/                     {   {SM_EXEC_REFUSED, SM_OPENED_FAULTED},                     {SM_EXEC_GRANTED, SM_CLOSING_FAULTED},                  {SM_EXEC_REFUSED, SM_OPENED_FAULTED},                     {SM_EXEC_REFUSED, SM_OPENED_FAULTED}},
+        /*SM_OPENED_DRAINING_TO_BARRIER*/         {   {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_BARRIER},         {SM_EXEC_GRANTED, SM_CLOSING},                          {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_BARRIER},         {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_BARRIER}},
+        /*SM_OPENED_DRAINING_TO_BARRIER_FAULTED*/ {   {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_BARRIER_FAULTED}, {SM_EXEC_GRANTED, SM_CLOSING_FAULTED},                  {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_BARRIER_FAULTED}, {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_BARRIER_FAULTED}},
+        /*SM_OPENED_DRAINING_TO_CLOSE*/           {   {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_CLOSE},           {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_CLOSE},         {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_CLOSE},           {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_CLOSE}},
+        /*SM_OPENED_DRAINING_TO_CLOSE_FAULTED*/   {   {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_CLOSE_FAULTED},   {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_CLOSE_FAULTED}, {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_CLOSE_FAULTED},   {SM_EXEC_REFUSED, SM_OPENED_DRAINING_TO_CLOSE_FAULTED}},
+        /*SM_OPENED_BARRIER*/                     {   {SM_EXEC_REFUSED, SM_OPENED_BARRIER},                     {SM_EXEC_GRANTED, SM_CLOSING},                          {SM_EXEC_REFUSED, SM_OPENED_BARRIER},                     {SM_EXEC_REFUSED, SM_OPENED_BARRIER}},
+        /*SM_OPENED_BARRIER_FAULTED*/             {   {SM_EXEC_REFUSED, SM_OPENED_BARRIER_FAULTED},             {SM_EXEC_GRANTED, SM_CLOSING_FAULTED},                  {SM_EXEC_REFUSED, SM_OPENED_BARRIER_FAULTED},             {SM_EXEC_REFUSED, SM_OPENED_BARRIER_FAULTED}},
+        /*SM_CLOSING*/                            {   {SM_EXEC_REFUSED, SM_CLOSING},                            {SM_EXEC_REFUSED, SM_CLOSING},                          {SM_EXEC_REFUSED, SM_CLOSING},                            {SM_EXEC_REFUSED, SM_CLOSING}},
+        /*SM_CLOSING_FAULTED*/                    {   {SM_EXEC_REFUSED, SM_CLOSING_FAULTED},                    {SM_EXEC_REFUSED, SM_CLOSING_FAULTED},                  {SM_EXEC_REFUSED, SM_CLOSING_FAULTED},                    {SM_EXEC_REFUSED, SM_CLOSING_FAULTED}}
     };
 
-    for (uint32_t i = 0 ; i < sizeof(expected) / sizeof(expected[0]); i++)
+    for (uint32_t i = 0 ; i < MU_COUNT_ARRAY_ITEMS(expected); i++)
     {
-        for (uint32_t j = 0; j < sizeof(expected[0]) / sizeof(expected[0][0]); j++)
+        for (uint32_t j = 0; j < MU_COUNT_ARRAY_ITEMS(expected[0]); j++)
         {
             SM_GO_TO_STATE goToState;
             (void)interlocked_exchange(&goToState.targetStateAPICalledInNextLine, 0);
@@ -1003,34 +1317,34 @@ TEST_FUNCTION(STATE_and_API)
             sm_switches_from_state_to_created(&goToState);
 
             ASSERT_ARE_EQUAL(INTERLOCKED_HL_RESULT, INTERLOCKED_HL_OK, InterlockedHL_WaitForValue(&goToState.targetStateAPICalledInNextLine, 1, UINT32_MAX));
-            
-            LogInfo("time[s]=%.2f, main thread: sleeping %" PRIu32 " miliseconds letting switchesToState thread finish its call", (timer_global_get_elapsed_ms() - timeSinceTestFunctionStartMs) / 1000, THREAD_DELAY);
+
+            LogInfo("time[s]=%.2f, main thread: sleeping %" PRIu32 " milliseconds letting switchesToState thread finish its call", (timer_global_get_elapsed_ms() - timeSinceTestFunctionStartMs) / 1000, THREAD_DELAY);
             ThreadAPI_Sleep(THREAD_DELAY);
 
             LogInfo("time[s]=%.2f, went to state=%" PRI_MU_ENUM "; calling=%" PRI_MU_ENUM "", (timer_global_get_elapsed_ms() - timeSinceTestFunctionStartMs) / 1000, MU_ENUM_VALUE(SM_STATES, (SM_STATES)(i + SM_CREATED)), MU_ENUM_VALUE(SM_APIS, (SM_APIS)(j + SM_OPEN_BEGIN)));
 
             switch (j)
             {
-                case 0:/*sm_open_begin*/
+                case SM_OPEN_BEGIN:/*sm_open_begin*/
                 {
                     ASSERT_ARE_EQUAL(INTERLOCKED_HL_RESULT, INTERLOCKED_HL_OK, InterlockedHL_SetAndWake(&goToState.targetAPICalledInNextLine, 1));
                     ASSERT_ARE_EQUAL(SM_RESULT, expected[i][j].expected_sm_result, sm_open_begin(goToState.sm));
                     break;
                 }
-                case 1:/*sm_close_begin*/
+                case SM_CLOSE_BEGIN:/*sm_close_begin*/
                 {
                     ASSERT_ARE_EQUAL(INTERLOCKED_HL_RESULT, INTERLOCKED_HL_OK, InterlockedHL_SetAndWake(&goToState.targetAPICalledInNextLine, 1));
                     ASSERT_ARE_EQUAL(SM_RESULT, expected[i][j].expected_sm_result, sm_close_begin(goToState.sm));
                     break;
                 }
-                case 2:/*sm_exec_begin*/
+                case SM_EXEC_BEGIN:/*sm_exec_begin*/
                 {
                     ASSERT_ARE_EQUAL(INTERLOCKED_HL_RESULT, INTERLOCKED_HL_OK, InterlockedHL_SetAndWake(&goToState.targetAPICalledInNextLine, 1));
                     ASSERT_ARE_EQUAL(SM_RESULT, expected[i][j].expected_sm_result, sm_exec_begin(goToState.sm));
                     sm_exec_end(goToState.sm);
                     break;
                 }
-                case 3:/*sm_barrier_begin*/
+                case SM_BARRIER_BEGIN:/*sm_barrier_begin*/
                 {
                     ASSERT_ARE_EQUAL(INTERLOCKED_HL_RESULT, INTERLOCKED_HL_OK, InterlockedHL_SetAndWake(&goToState.targetAPICalledInNextLine, 1));
                     ASSERT_ARE_EQUAL(SM_RESULT, expected[i][j].expected_sm_result, sm_barrier_begin(goToState.sm));

--- a/tests/sm_int/sm_int.c
+++ b/tests/sm_int/sm_int.c
@@ -4,10 +4,12 @@
 #ifdef __cplusplus
 #include <cinttypes>
 #include <cstdlib>
+#include <ctime>
 #else
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <time.h>
 #endif
 
 #include "testrunnerswitcher.h"
@@ -488,6 +490,7 @@ static int callsBeginAndEnd(
 )
 {
     OPEN_CLOSE_THREADS* data = (OPEN_CLOSE_THREADS*)arg;
+    srand((unsigned int)time(NULL));
 
     while (interlocked_add(&data->threadsShouldFinish, 0) == 0)
     {
@@ -528,12 +531,14 @@ static int callsFault(
 )
 {
     OPEN_CLOSE_THREADS* data = (OPEN_CLOSE_THREADS*)arg;
+    srand((unsigned int)time(NULL));
 
     while (interlocked_add(&data->threadsShouldFinish, 0) == 0)
     {
         uint32_t time_before_next_fault = rand() % 300;
         ThreadAPI_Sleep(time_before_next_fault);
         sm_fault(data->sm);
+        (void)interlocked_increment(&data->n_faults);
     }
     return 0;
 }
@@ -867,7 +872,7 @@ TEST_FUNCTION(sm_chaos)
 
     xlogging_set_log_function(toBeRestored);
 }
-
+#if 0
 TEST_FUNCTION(sm_does_not_block)
 {
     LogInfo("disabling logging for the duration of sm_does_not_block. Logging takes additional locks that \"might help\" the test pass");
@@ -1361,5 +1366,5 @@ TEST_FUNCTION(STATE_and_API)
         }
     }
 }
-
+#endif
 END_TEST_SUITE(sm_int_tests)

--- a/tests/sm_int/sm_int.c
+++ b/tests/sm_int/sm_int.c
@@ -1183,14 +1183,8 @@ static int switchesFromStateToCreated(
         case SM_OPENED:
         case SM_OPENED_FAULTED:
         {
-            if (sm_close_begin(goToState->sm) == SM_EXEC_GRANTED)
-            {
-                sm_close_end(goToState->sm);
-            }
-            else
-            {
-                ASSERT_FAIL("Why?");
-            }
+            ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_close_begin(goToState->sm));
+            sm_close_end(goToState->sm);
 
             break;
         }
@@ -1207,14 +1201,8 @@ static int switchesFromStateToCreated(
 
             ThreadAPI_Sleep(THREAD_DELAY);
 
-            if (sm_close_begin(goToState->sm) == SM_EXEC_GRANTED)
-            {
-                sm_close_end(goToState->sm);
-            }
-            else
-            {
-                ASSERT_FAIL("Why?");
-            }
+            ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_close_begin(goToState->sm));
+            sm_close_end(goToState->sm);
             break;
 
         }
@@ -1341,13 +1329,20 @@ TEST_FUNCTION(STATE_and_API)
                 {
                     ASSERT_ARE_EQUAL(INTERLOCKED_HL_RESULT, INTERLOCKED_HL_OK, InterlockedHL_SetAndWake(&goToState.targetAPICalledInNextLine, 1));
                     ASSERT_ARE_EQUAL(SM_RESULT, expected[i][j].expected_sm_result, sm_exec_begin(goToState.sm));
-                    sm_exec_end(goToState.sm);
+                    if (expected[i][j].expected_sm_result == SM_EXEC_GRANTED)
+                    {
+                        sm_exec_end(goToState.sm);
+                    }
                     break;
                 }
                 case SM_BARRIER_BEGIN:/*sm_barrier_begin*/
                 {
                     ASSERT_ARE_EQUAL(INTERLOCKED_HL_RESULT, INTERLOCKED_HL_OK, InterlockedHL_SetAndWake(&goToState.targetAPICalledInNextLine, 1));
                     ASSERT_ARE_EQUAL(SM_RESULT, expected[i][j].expected_sm_result, sm_barrier_begin(goToState.sm));
+                    if (expected[i][j].expected_sm_result == SM_EXEC_GRANTED)
+                    {
+                        sm_barrier_end(goToState.sm);
+                    }
                     break;
                 }
                 default:

--- a/tests/sm_ut/sm_ut.c
+++ b/tests/sm_ut/sm_ut.c
@@ -157,7 +157,7 @@ TEST_FUNCTION(sm_create_unhappy_path)
 TEST_FUNCTION(sm_destroy_with_sm_NULL_returns)
 {
     ///arrange
-    
+
     ///act
     sm_destroy(NULL);
 
@@ -286,7 +286,7 @@ TEST_FUNCTION(sm_open_end_switches_to_SM_OPENED)
     SM_RESULT result1 = sm_exec_begin(sm);
     sm_open_end(sm, true);
     SM_RESULT result2 = sm_exec_begin(sm);
-    
+
     ///assert
     ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_REFUSED, result1);
     ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result2);
@@ -297,7 +297,7 @@ TEST_FUNCTION(sm_open_end_switches_to_SM_OPENED)
     sm_destroy(sm);
 }
 
-/*Tests_SRS_SM_02_075: [ If success is false then sm_open_end shall switch the state to SM_CREATED. ]*/
+/*Tests_SRS_SM_02_075: [ If success is false then sm_open_end shall switch the state to SM_CREATED and reset the SM_FAULTED_BIT to 0. ]*/
 TEST_FUNCTION(sm_open_end_switches_to_SM_CREATED)
 {
     ///arrange
@@ -317,6 +317,33 @@ TEST_FUNCTION(sm_open_end_switches_to_SM_CREATED)
 
     ///clean
     sm_open_end(sm, true);
+    sm_destroy(sm);
+}
+
+/*Tests_SRS_SM_02_075: [ If success is false then sm_open_end shall switch the state to SM_CREATED and reset the SM_FAULTED_BIT to 0. ]*/
+TEST_FUNCTION(sm_open_end_switches_to_SM_CREATED_and_resets_SM_FAULTED_BIT)
+{
+    ///arrange
+    SM_HANDLE sm = TEST_sm_create();
+    SM_RESULT result = sm_open_begin(sm);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result);
+    sm_fault(sm);
+
+    ///act
+    SM_RESULT result1 = sm_exec_begin(sm);
+    sm_open_end(sm, false);
+    SM_RESULT result2 = sm_open_begin(sm); /*sm_open_begin can only be executed in SM_CREATED state*/
+    sm_open_end(sm, true);
+    SM_RESULT result3 = sm_exec_begin(sm); /*sm_exec_begin would fail if the fault wasn't reset*/
+
+    ///assert
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_REFUSED, result1);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result2);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result3);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///clean
+    sm_exec_end(sm);
     sm_destroy(sm);
 }
 
@@ -414,7 +441,7 @@ TEST_FUNCTION(sm_close_begin_after_close_begin_close_end_open_begin_open_end_suc
     ///arrange
     SM_HANDLE sm = TEST_sm_create();
     SM_RESULT result;
-    
+
     result = sm_open_begin(sm);
     ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result);
     sm_open_end(sm, true);
@@ -463,7 +490,7 @@ TEST_FUNCTION(sm_close_unhappy_path)
 
     ///act
     result = sm_close_begin(sm);
-   
+
     ///assert
     ASSERT_ARE_EQUAL(SM_RESULT, SM_ERROR, result);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -526,6 +553,38 @@ TEST_FUNCTION(sm_close_end_switches_state_to_SM_CREATED) /*allows sm_open_begin 
     ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     sm_open_end(sm, true);
+
+    ///clean
+    sm_destroy(sm);
+}
+
+/*Tests_SRS_SM_42_001: [ sm_close_end shall reset SM_FAULTED_BIT to 0. ]*/
+TEST_FUNCTION(sm_close_end_resets_SM_FAULTED_BIT) /*allows sm_exec_begin to be called after a new open*/
+{
+    ///arrange
+    SM_HANDLE sm = TEST_sm_create();
+    SM_RESULT result;
+
+    result = sm_open_begin(sm);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result);
+    sm_open_end(sm, true);
+
+    STRICT_EXPECTED_CALL(InterlockedHL_WaitForValue(IGNORED_ARG, 0, UINT32_MAX));
+
+    result = sm_close_begin(sm);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result);
+
+    umock_c_reset_all_calls();
+
+    ///act
+    sm_close_end(sm);
+
+    ///assert
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_open_begin(sm));
+    sm_open_end(sm, true);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_exec_begin(sm));
+    sm_exec_end(sm);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     ///clean
     sm_destroy(sm);
@@ -595,6 +654,32 @@ TEST_FUNCTION(sm_exec_begin_succeeds)
     sm_destroy(sm);
 }
 
+/*Tests_SRS_SM_42_007: [ sm_fault shall set SM_FAULTED_BIT to 1. ]*/
+/*Tests_SRS_SM_42_002: [ If SM_FAULTED_BIT is 1 then sm_exec_begin shall return SM_EXEC_REFUSED. ]*/
+TEST_FUNCTION(sm_exec_begin_fails_when_faulted)
+{
+    ///arrange
+    SM_HANDLE sm = TEST_sm_create();
+    SM_RESULT result;
+    result = sm_open_begin(sm);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result);
+    sm_open_end(sm, true);
+
+    sm_fault(sm);
+
+    umock_c_reset_all_calls();
+
+    ///act
+    result = sm_exec_begin(sm);
+
+    ///assert
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_REFUSED, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///clean
+    sm_destroy(sm);
+}
+
 /*Tests_SRS_SM_02_024: [ If sm is NULL then sm_exec_end shall return. ]*/
 TEST_FUNCTION(sm_exec_end_with_sm_NULL_returns)
 {
@@ -640,6 +725,37 @@ TEST_FUNCTION(sm_exec_end_signals)
 
     result = sm_exec_begin(sm);
     ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result);
+
+    umock_c_reset_all_calls();
+
+    ///act
+    sm_exec_end(sm);
+    sm_exec_end(sm);
+
+    ///assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    result = sm_close_begin(sm);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result); /*if somehow n would be -1... sm_close_end would wait forever...*/
+    sm_close_end(sm);
+
+    ///clean
+    sm_destroy(sm);
+}
+
+TEST_FUNCTION(sm_exec_end_works_when_faulted)
+{
+    ///arrange
+    SM_HANDLE sm = TEST_sm_create();
+    SM_RESULT result;
+    result = sm_open_begin(sm);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result);
+    sm_open_end(sm, true);
+
+    result = sm_exec_begin(sm);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result);
+
+    sm_fault(sm);
 
     umock_c_reset_all_calls();
 
@@ -717,6 +833,32 @@ TEST_FUNCTION(sm_barrier_begin_with_SM_CLOSE_BIT_set_refuses)
     sm_destroy(sm);
 }
 
+/*Tests_SRS_SM_42_007: [ sm_fault shall set SM_FAULTED_BIT to 1. ]*/
+/*Tests_SRS_SM_42_003: [ If SM_FAULTED_BIT is set to 1 then sm_barrier_begin shall return SM_EXEC_REFUSED. ]*/
+TEST_FUNCTION(sm_barrier_begin_with_SM_FAULTED_BIT_set_refuses)
+{
+    ///arrange
+    SM_HANDLE sm = TEST_sm_create();
+    SM_RESULT result;
+    result = sm_open_begin(sm);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result);
+    sm_open_end(sm, true);
+
+    sm_fault(sm);
+
+    umock_c_reset_all_calls();
+
+    ///act
+    result = sm_barrier_begin(sm);
+
+    ///assert
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_REFUSED, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///clean
+    sm_destroy(sm);
+}
+
 /*Tests_SRS_SM_02_066: [ sm_barrier_begin shall switch the state to SM_OPENED_DRAINING_TO_BARRIER. ]*/
 /*Tests_SRS_SM_02_069: [ sm_barrier_begin shall switch the state to SM_OPENED_BARRIER and return SM_EXEC_GRANTED. ]*/
 TEST_FUNCTION(sm_barrier_begin_returns_SM_EXEC_GRANTED)
@@ -741,6 +883,31 @@ TEST_FUNCTION(sm_barrier_begin_returns_SM_EXEC_GRANTED)
 
     ///clean
     sm_barrier_end(sm);
+    sm_destroy(sm);
+}
+
+TEST_FUNCTION(sm_barrier_end_works_when_faulted)
+{
+    ///arrange
+    SM_HANDLE sm = TEST_sm_create();
+    SM_RESULT result;
+    result = sm_open_begin(sm);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result);
+    sm_open_end(sm, true);
+
+    STRICT_EXPECTED_CALL(InterlockedHL_WaitForValue(IGNORED_ARG, 0, UINT32_MAX));
+
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_barrier_begin(sm));
+
+    sm_fault(sm);
+
+    ///act
+    sm_barrier_end(sm);
+
+    ///assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///clean
     sm_destroy(sm);
 }
 
@@ -788,7 +955,7 @@ TEST_FUNCTION(sm_barrier_end_in_SM_CREATED_returns)
 {
     ///arrange
     SM_HANDLE sm = TEST_sm_create();
-    
+
     ///act
     sm_barrier_end(sm);
 
@@ -827,6 +994,74 @@ TEST_FUNCTION(sm_barrier_begin_switched_to_SM_OPENED)
 
     ///clean
     sm_exec_end(sm);
+    sm_destroy(sm);
+}
+
+//
+// sm_fault
+//
+
+/*Tests_SRS_SM_42_004: [ If sm is NULL then sm_fault shall return. ]*/
+TEST_FUNCTION(sm_fault_with_NULL_sm_returns)
+{
+    ///arrange
+
+    ///act
+    sm_fault(NULL);
+
+    ///assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/*Tests_SRS_SM_42_006: [ If the state is SM_CREATED then sm_fault shall return. ]*/
+TEST_FUNCTION(sm_fault_in_SM_CREATED_returns_can_still_exec_after_open)
+{
+    ///arrange
+    SM_HANDLE sm = TEST_sm_create();
+
+    ///act
+    sm_fault(sm);
+
+    ///assert
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_open_begin(sm));
+    sm_open_end(sm, true);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_exec_begin(sm));
+    sm_exec_end(sm);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///clean
+    sm_destroy(sm);
+}
+
+/*Tests_SRS_SM_42_008: [ If the state is SM_CLOSING then sm_fault shall return. ]*/
+TEST_FUNCTION(sm_fault_in_SM_CLOSING_returns_can_still_exec_after_open)
+{
+    ///arrange
+    SM_HANDLE sm = TEST_sm_create();
+
+    SM_RESULT result;
+
+    result = sm_open_begin(sm);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result);
+    sm_open_end(sm, true);
+
+    STRICT_EXPECTED_CALL(InterlockedHL_WaitForValue(IGNORED_ARG, 0, UINT32_MAX));
+
+    result = sm_close_begin(sm);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, result);
+
+    ///act
+    sm_fault(sm);
+
+    ///assert
+    sm_close_end(sm);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_open_begin(sm));
+    sm_open_end(sm, true);
+    ASSERT_ARE_EQUAL(SM_RESULT, SM_EXEC_GRANTED, sm_exec_begin(sm));
+    sm_exec_end(sm);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///clean
     sm_destroy(sm);
 }
 

--- a/tests/sm_ut/sm_ut.c
+++ b/tests/sm_ut/sm_ut.c
@@ -578,6 +578,7 @@ TEST_FUNCTION(sm_close_end_switches_state_to_SM_CREATED) /*allows sm_open_begin 
     sm_destroy(sm);
 }
 
+/*Tests_SRS_SM_42_012: [ sm_close_end shall not reset the SM_FAULTED_BIT. ]*/
 TEST_FUNCTION(sm_close_end_switches_state_to_SM_CREATED_leaves_SM_FAULTED_BIT_set)
 {
     ///arrange
@@ -793,6 +794,7 @@ TEST_FUNCTION(sm_exec_end_called_additional_time_terminates_process)
     sm_destroy(sm);
 }
 
+/*Tests_SRS_SM_42_013: [ sm_exec_end may be called when SM_FAULTED_BIT is 1. ]*/
 TEST_FUNCTION(sm_exec_end_works_when_faulted)
 {
     ///arrange
@@ -935,6 +937,7 @@ TEST_FUNCTION(sm_barrier_begin_returns_SM_EXEC_GRANTED)
     sm_destroy(sm);
 }
 
+/*Tests_SRS_SM_42_014: [ sm_barrier_end may be called when SM_FAULTED_BIT is 1. ]*/
 TEST_FUNCTION(sm_barrier_end_works_when_faulted)
 {
     ///arrange


### PR DESCRIPTION
- Fix sm_int chaos test so that end calls are always paired with begin
- Add sm_fault, which disallows new operations except close
- Add retry loops when state changes in barrier and close end so we don't silently fail and get stuck
- Fail fast if sm_exec_end is called too many times and the count would go negative