### PR TITLE
fix dlist append

### DIFF
--- a/devdoc/doublylinkedlist_requirements.md
+++ b/devdoc/doublylinkedlist_requirements.md
@@ -89,10 +89,10 @@ DList_InsertHeadList shall assume listHead and listEntry non-NULL and pointing t
 
 ### DList_AppendTailList
 ```c
-void DList_AppendTailList(PDLIST_ENTRY listHead, PDLIST_ENTRY ListToAppend);
+void DList_AppendTailList(PDLIST_ENTRY listHead, PDLIST_ENTRY listToBeAppendedHead);
 ```
 
-**SRS_DLIST_06_007: [** DList_AppendTailList shall place the list defined by listToAppend at the end of the list defined by the listHead parameter. **]**
+**SRS_DLIST_06_007: [** DList_AppendTailList shall place the list defined by `listToBeAppendedHead` at the end of the list defined by the `listHead` parameter. **]**
 
 ### DList_RemoveEntryList
 ```c

--- a/src/doublylinkedlist.c
+++ b/src/doublylinkedlist.c
@@ -106,19 +106,24 @@ DList_InsertTailList(
 void
 DList_AppendTailList(
     PDLIST_ENTRY ListHead,
-    PDLIST_ENTRY ListToAppend
+    PDLIST_ENTRY ListToBeAppendedHead
 )
 {
-    /* Codes_SRS_DLIST_06_007: [DList_AppendTailList shall place the list defined by listToAppend at the end of the list defined by the listHead parameter.] */
-    PDLIST_ENTRY ListEnd = ListHead->Blink;
+    if (!DList_IsListEmpty(ListToBeAppendedHead))
+    {
+        /* Codes_SRS_DLIST_06_007: [DList_AppendTailList shall place the list defined by listToBeAppendedHead at the end of the list defined by the listHead parameter.] */
+        PDLIST_ENTRY ListEnd = ListHead->Blink;
 
-    ListHead->Blink->Flink = ListToAppend;
-    ListHead->Blink = ListToAppend->Blink;
-    ListToAppend->Blink->Flink = ListHead;
-    ListToAppend->Blink = ListEnd;
+        ListHead->Blink->Flink = ListToBeAppendedHead->Flink;
+        ListHead->Blink = ListToBeAppendedHead->Blink;
+        ListToBeAppendedHead->Blink->Flink = ListHead;
+        ListToBeAppendedHead->Flink->Blink = ListEnd;
+
+        DList_InitializeListHead(ListToBeAppendedHead);
+    }
+
     return;
 }
-
 
 /*Codes_SRS_DLIST_02_002: [DList_InsertHeadList inserts a singular entry in the list having as head listHead after "head".]*/
 void DList_InsertHeadList(PDLIST_ENTRY listHead, PDLIST_ENTRY entry)

--- a/tests/doublylinkedlist_ut/doublylinkedlist_ut.c
+++ b/tests/doublylinkedlist_ut/doublylinkedlist_ut.c
@@ -177,20 +177,23 @@ TEST_FUNCTION_CLEANUP(TestMethodCleanup)
     }
 
     /* Tests_SRS_DLIST_06_007: [DList_AppendTailList shall place the list defined by ListToAppend at the end of the list defined by the listHead parameter.] */
-    TEST_FUNCTION(DList_AppendTailList_adds_listToAppend_after_listHead)
+    TEST_FUNCTION(DList_AppendTailList_adds_listToBeAppended_after_listHead)
     {
         // arrange
         DLIST_ENTRY listHead;
         PDLIST_ENTRY currentEntry;
 
         DList_InitializeListHead(&listHead);
-        DList_InsertTailList(&listHead, &(simp1.link));
+        DList_InsertTailList(&listHead, &simp1.link);
+        DList_InsertTailList(&listHead, &simp2.link);
 
-        DList_InitializeListHead(&simp2.link);
-        DList_InsertTailList(&simp2.link, &simp4.link);
-        DList_InsertTailList(&simp2.link, &simp5.link);
+        DLIST_ENTRY listToBeAppendedHead;
+        DList_InitializeListHead(&listToBeAppendedHead);
+        DList_InsertTailList(&listToBeAppendedHead, &simp3.link);
+        DList_InsertTailList(&listToBeAppendedHead, &simp4.link);
+        DList_InsertTailList(&listToBeAppendedHead, &simp5.link);
         // act
-        DList_AppendTailList(&listHead, &simp2.link);
+        DList_AppendTailList(&listHead, &listToBeAppendedHead);
 
         // assert
         // Go forwards
@@ -201,6 +204,9 @@ TEST_FUNCTION_CLEANUP(TestMethodCleanup)
         currentEntry = currentEntry->Flink;
         ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp2.link);
         ASSERT_ARE_EQUAL(short, (short)2, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
+        currentEntry = currentEntry->Flink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp3.link);
+        ASSERT_ARE_EQUAL(short, (short)3, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
         currentEntry = currentEntry->Flink;
         ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp4.link);
         ASSERT_ARE_EQUAL(short, (short)4, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
@@ -221,6 +227,9 @@ TEST_FUNCTION_CLEANUP(TestMethodCleanup)
         ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp4.link);
         ASSERT_ARE_EQUAL(short, (short)4, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
         currentEntry = currentEntry->Blink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp3.link);
+        ASSERT_ARE_EQUAL(short, (short)3, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
+        currentEntry = currentEntry->Blink;
         ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp2.link);
         ASSERT_ARE_EQUAL(short, (short)2, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
         currentEntry = currentEntry->Blink;
@@ -228,7 +237,155 @@ TEST_FUNCTION_CLEANUP(TestMethodCleanup)
         ASSERT_ARE_EQUAL(short, (short)1, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
         currentEntry = currentEntry->Blink;
         ASSERT_ARE_EQUAL(void_ptr, currentEntry, &listHead);
+
+        ASSERT_ARE_NOT_EQUAL(int, 0, DList_IsListEmpty(&listToBeAppendedHead));
     }
+
+    /* Tests_SRS_DLIST_06_007: [DList_AppendTailList shall place the list defined by ListToAppend at the end of the list defined by the listHead parameter.] */
+    TEST_FUNCTION(DList_AppendTailList_with_one_entry_in_both_list)
+    {
+        // arrange
+        DLIST_ENTRY listHead;
+        PDLIST_ENTRY currentEntry;
+
+        DList_InitializeListHead(&listHead);
+        DList_InsertTailList(&listHead, &simp1.link);
+
+        DLIST_ENTRY listToBeAppendedHead;
+        DList_InitializeListHead(&listToBeAppendedHead);
+        DList_InsertTailList(&listToBeAppendedHead, &simp2.link);
+
+        // act
+        DList_AppendTailList(&listHead, &listToBeAppendedHead);
+
+        // assert
+        // Go forwards
+        ASSERT_ARE_EQUAL(int, 0, DList_IsListEmpty(&listHead));
+        currentEntry = listHead.Flink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp1.link);
+        ASSERT_ARE_EQUAL(short, (short)1, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
+        currentEntry = currentEntry->Flink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp2.link);
+        ASSERT_ARE_EQUAL(short, (short)2, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
+        currentEntry = currentEntry->Flink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &listHead);
+
+        // Now back
+        currentEntry = listHead.Blink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp2.link);
+        ASSERT_ARE_EQUAL(short, (short)2, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
+        currentEntry = currentEntry->Blink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp1.link);
+        ASSERT_ARE_EQUAL(short, (short)1, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
+        currentEntry = currentEntry->Blink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &listHead);
+
+        ASSERT_ARE_NOT_EQUAL(int, 0, DList_IsListEmpty(&listToBeAppendedHead));
+    }
+
+    /* Tests_SRS_DLIST_06_007: [DList_AppendTailList shall place the list defined by ListToAppend at the end of the list defined by the listHead parameter.] */
+    TEST_FUNCTION(DList_AppendTailList_with_empty_listToBeAppendedHead)
+    {
+        // arrange
+        DLIST_ENTRY listHead;
+        PDLIST_ENTRY currentEntry;
+
+        DList_InitializeListHead(&listHead);
+        DList_InsertTailList(&listHead, &simp1.link);
+        DList_InsertTailList(&listHead, &simp2.link);
+
+        DLIST_ENTRY listToBeAppendedHead;
+        DList_InitializeListHead(&listToBeAppendedHead);
+
+        // act
+        DList_AppendTailList(&listHead, &listToBeAppendedHead);
+
+        // assert
+        // Go forwards
+        ASSERT_ARE_EQUAL(int, 0, DList_IsListEmpty(&listHead));
+        currentEntry = listHead.Flink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp1.link);
+        ASSERT_ARE_EQUAL(short, (short)1, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
+        currentEntry = currentEntry->Flink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp2.link);
+        ASSERT_ARE_EQUAL(short, (short)2, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
+        currentEntry = currentEntry->Flink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &listHead);
+
+        // Now back
+        currentEntry = listHead.Blink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp2.link);
+        ASSERT_ARE_EQUAL(short, (short)2, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
+        currentEntry = currentEntry->Blink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp1.link);
+        ASSERT_ARE_EQUAL(short, (short)1, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
+        currentEntry = currentEntry->Blink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &listHead);
+
+        ASSERT_ARE_NOT_EQUAL(int, 0, DList_IsListEmpty(&listToBeAppendedHead));
+    }
+
+    /* Tests_SRS_DLIST_06_007: [DList_AppendTailList shall place the list defined by ListToAppend at the end of the list defined by the listHead parameter.] */
+    TEST_FUNCTION(DList_AppendTailList_with_empty_listHead)
+    {
+        // arrange
+        DLIST_ENTRY listHead;
+        PDLIST_ENTRY currentEntry;
+
+        DList_InitializeListHead(&listHead);
+
+        DLIST_ENTRY listToBeAppendedHead;
+        DList_InitializeListHead(&listToBeAppendedHead);
+        DList_InsertTailList(&listToBeAppendedHead, &simp1.link);
+        DList_InsertTailList(&listToBeAppendedHead, &simp2.link);
+
+        // act
+        DList_AppendTailList(&listHead, &listToBeAppendedHead);
+
+        // assert
+        // Go forwards
+        ASSERT_ARE_EQUAL(int, 0, DList_IsListEmpty(&listHead));
+        currentEntry = listHead.Flink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp1.link);
+        ASSERT_ARE_EQUAL(short, (short)1, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
+        currentEntry = currentEntry->Flink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp2.link);
+        ASSERT_ARE_EQUAL(short, (short)2, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
+        currentEntry = currentEntry->Flink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &listHead);
+
+        // Now back
+        currentEntry = listHead.Blink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp2.link);
+        ASSERT_ARE_EQUAL(short, (short)2, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
+        currentEntry = currentEntry->Blink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &simp1.link);
+        ASSERT_ARE_EQUAL(short, (short)1, CONTAINING_RECORD(currentEntry, simpleItem, link)->index);
+        currentEntry = currentEntry->Blink;
+        ASSERT_ARE_EQUAL(void_ptr, currentEntry, &listHead);
+
+        ASSERT_ARE_NOT_EQUAL(int, 0, DList_IsListEmpty(&listToBeAppendedHead));
+    }
+
+    /* Tests_SRS_DLIST_06_007: [DList_AppendTailList shall place the list defined by ListToAppend at the end of the list defined by the listHead parameter.] */
+    TEST_FUNCTION(DList_AppendTailList_with_both_list_empty)
+    {
+        // arrange
+        DLIST_ENTRY listHead;
+        DList_InitializeListHead(&listHead);
+
+        DLIST_ENTRY listToBeAppendedHead;
+        DList_InitializeListHead(&listToBeAppendedHead);
+
+
+        // act
+        DList_AppendTailList(&listHead, &listToBeAppendedHead);
+
+        // assert
+        ASSERT_ARE_NOT_EQUAL(int, 0, DList_IsListEmpty(&listHead));
+        ASSERT_ARE_NOT_EQUAL(int, 0, DList_IsListEmpty(&listToBeAppendedHead));
+    }
+
 
     /* Tests_SRS_DLIST_06_010: [DList_RemoveEntryList shall return non-zero if the remaining list is empty.] */
     TEST_FUNCTION(DList_RemoveEntryList_with_head_only_in_list_shall_return_non_zero)


### PR DESCRIPTION
Fix an issue where DList_AppendTailList includes the head (contains no data) of the list to be appended in the middle of the final list.  Now the 2nd argument is expected to be the list head of the to be appended list.