### PR TITLE
Make rc_string_create_with_format mockable like sprintf_char

### DIFF
--- a/devdoc/rc_string_requirements.md
+++ b/devdoc/rc_string_requirements.md
@@ -22,10 +22,16 @@
     #define RC_STRING_VALUE_OR_NULL(rc) (((rc) == NULL) ? "NULL" : (rc)->string)
 
     MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create, const char*, string);
-    THANDLE(RC_STRING) rc_string_create_with_format(const char* string, ...);
     MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_move_memory, const char*, string);
     MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_custom_free, const char*, string, RC_STRING_FREE_FUNC, free_func, void*, free_func_context);
     MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_recreate, THANDLE(RC_STRING), self);
+
+    // Macro for mockable rc_string_create_with_vformat to verify the arguments as if printf was called
+    #define rc_string_create_with_format(format, ...) (0?printf((format), ## __VA_ARGS__):0, rc_string_create_with_format_function((format), ##__VA_ARGS__))
+    // The non-mockable function for rc_string_create_with_vformat (because we can't mock ... arguments)
+    THANDLE(RC_STRING) rc_string_create_with_format_function(const char* format, ...);
+    // The mockable function, called by rc_string_create_with_format_function
+    MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_vformat, const char*, format, va_list, va);
 ```
 
 ## RC_STRING_VALUE
@@ -74,31 +80,31 @@ MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create, const char*, string);
 
 **SRS_RC_STRING_01_006: [** If any error occurs, `rc_string_create` shall fail and return `NULL`. **]**
 
-## rc_string_create_with_format
+## rc_string_create_with_vformat
 
 ```c
-THANDLE(RC_STRING) rc_string_create_with_format(const char* format, ...);
+MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_vformat, const char*, format, va_list, va);
 ```
 
-`rc_string_create_with_format` creates a new ref counted string by using the format convention as in sprintf.
+`rc_string_create_with_vformat` creates a new ref counted string by using the format convention as in sprintf.
 
-**SRS_RC_STRING_07_001: [** If `format` is `NULL`, `rc_string_create_with_format` shall fail and return `NULL`. **]** 
+**SRS_RC_STRING_07_001: [** If `format` is `NULL`, `rc_string_create_with_vformat` shall fail and return `NULL`. **]** 
 
-**SRS_RC_STRING_07_002: [** Otherwise `rc_string_create_with_format` shall determine the total number of characters written using `vsnprintf` with the variable number of arguments. **]**  
+**SRS_RC_STRING_07_002: [** Otherwise `rc_string_create_with_vformat` shall determine the total number of characters written using `vsnprintf` with the variable number of arguments. **]**  
 
-**SRS_RC_STRING_07_003: [** If `vsnprintf` failed to determine the total number of characters written, `rc_string_create_with_format` shall fail and return `NULL`. **]**
+**SRS_RC_STRING_07_003: [** If `vsnprintf` failed to determine the total number of characters written, `rc_string_create_with_vformat` shall fail and return `NULL`. **]**
 
-**SRS_RC_STRING_07_004: [** `rc_string_create_with_format` shall allocate memory for the `THANDLE(RC_STRING)` and the number of bytes for the resulting formatted string. **]**
+**SRS_RC_STRING_07_004: [** `rc_string_create_with_vformat` shall allocate memory for the `THANDLE(RC_STRING)` and the number of bytes for the resulting formatted string. **]**
 
-**SRS_RC_STRING_07_009: [** If the resulting memory size requested for the `THANDLE(RC_STRING)` and the resulting formatted string results in an size_t overflow in `malloc_flex`, `rc_string_create_with_format` shall fail and return `NULL`. **]**
+**SRS_RC_STRING_07_009: [** If the resulting memory size requested for the `THANDLE(RC_STRING)` and the resulting formatted string results in an size_t overflow in `malloc_flex`, `rc_string_create_with_vformat` shall fail and return `NULL`. **]**
 
-**SRS_RC_STRING_07_005: [** `rc_string_create_with_format` shall fill in the bytes of the string by using `vsnprintf`. **]**
+**SRS_RC_STRING_07_005: [** `rc_string_create_with_vformat` shall fill in the bytes of the string by using `vsnprintf`. **]**
 
-**SRS_RC_STRING_07_006: [** If `vsnprintf` failed to construct the resulting formatted string, `rc_string_create_with_format` shall fail and return `NULL`. **]**
+**SRS_RC_STRING_07_006: [** If `vsnprintf` failed to construct the resulting formatted string, `rc_string_create_with_vformat` shall fail and return `NULL`. **]**
 
-**SRS_RC_STRING_07_007: [** `rc_string_create_with_format` shall succeed and return a non-`NULL` handle. **]** 
+**SRS_RC_STRING_07_007: [** `rc_string_create_with_vformat` shall succeed and return a non-`NULL` handle. **]** 
 
-**SRS_RC_STRING_07_008: [** If any error occurs, `rc_string_create_with_format` shall fail and return `NULL`. **]**
+**SRS_RC_STRING_07_008: [** If any error occurs, `rc_string_create_with_vformat` shall fail and return `NULL`. **]**
 
 ## rc_string_create_with_move_memory
 

--- a/inc/c_util/rc_string.h
+++ b/inc/c_util/rc_string.h
@@ -6,7 +6,9 @@
 
 #ifdef __cplusplus
 #include <cstddef>
+#include <cstdarg>
 #else
+#include <stdarg.h>
 #include <stddef.h>
 #endif
 
@@ -38,10 +40,16 @@ extern "C"
 #define RC_STRING_VALUE_OR_NULL(rc) (((rc) == NULL) ? "NULL" : (rc)->string)
 
     MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create, const char*, string);
-    THANDLE(RC_STRING) rc_string_create_with_format(const char* format, ...);
     MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_move_memory, const char*, string);
     MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_custom_free, const char*, string, RC_STRING_FREE_FUNC, free_func, void*, free_func_context);
     MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_recreate, THANDLE(RC_STRING), self);
+
+    // Macro for mockable rc_string_create_with_vformat to verify the arguments as if printf was called
+    #define rc_string_create_with_format(format, ...) (0?printf((format), ## __VA_ARGS__):0, rc_string_create_with_format_function((format), ##__VA_ARGS__))
+    // The non-mockable function for rc_string_create_with_vformat (because we can't mock ... arguments)
+    THANDLE(RC_STRING) rc_string_create_with_format_function(const char* format, ...);
+    // The mockable function, called by rc_string_create_with_format_function
+    MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_vformat, const char*, format, va_list, va);
 
 #ifdef __cplusplus
 }

--- a/src/rc_string.c
+++ b/src/rc_string.c
@@ -75,7 +75,7 @@ static THANDLE(RC_STRING) rc_string_create_impl(const char* string)
 
     if (string_length_with_terminator > SIZE_MAX - (sizeof(RC_STRING_INTERNAL) - sizeof(RC_STRING)))
     {
-        /* Codes_SRS_RC_STRING_07_010: [ If the resulting memory size requested for the `THANDLE(RC_STRING)`and `string` results in an size_t overflow, `rc_string_create` shall failand return `NULL`. ]*/
+        /* Codes_SRS_RC_STRING_07_010: [ If the resulting memory size requested for the THANDLE(RC_STRING)and string results in an size_t overflow, rc_string_create shall fail and return NULL. ]*/
         LogError("Size_t overflowed, extra size is %zu, string_length_with_terminator=%zu", sizeof(RC_STRING_INTERNAL) - sizeof(RC_STRING) + string_length_with_terminator, string_length_with_terminator);
     }
     else
@@ -120,46 +120,43 @@ IMPLEMENT_MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create, const char*,
     return result;
 }
 
-
-THANDLE(RC_STRING) rc_string_create_with_format(const char* format, ...)
+IMPLEMENT_MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_vformat, const char*, format, va_list, va)
 {
     THANDLE(RC_STRING) result = NULL;
 
     if (format == NULL)
     {
-        /*Codes_SRS_RC_STRING_07_001: [ If format is NULL, rc_string_create_with_format shall fail and return NULL. ]*/
+        /*Codes_SRS_RC_STRING_07_001: [ If format is NULL, rc_string_create_with_vformat shall fail and return NULL. ]*/
         LogError("Invalid arguments: const char* format=%s", MU_P_OR_NULL(format));
     }
     else
     {
-        /*Codes_SRS_RC_STRING_07_002: [ Otherwise, `rc_string_create_with_format` shall determine the total number of characters written using the variable number of arguments. ]*/
-        va_list args;
+        /*Codes_SRS_RC_STRING_07_002: [ Otherwise, rc_string_create_with_vformat shall determine the total number of characters written using the variable number of arguments. ]*/
         va_list args_copy;
-        va_start(args, format);
-        va_copy(args_copy, args);
+        va_copy(args_copy, va);
 
-        int string_length = vsnprintf(NULL, 0, format, args);
+        int string_length = vsnprintf(NULL, 0, format, va);
         int string_length_with_terminator = string_length + 1;
-        
+
         if (string_length < 0)
         {
-            /*Codes_SRS_RC_STRING_07_003: [ If `vsnprintf` failed to determine the total number of characters written, `rc_string_create_with_format` shall fail and return `NULL`. ]*/
+            /*Codes_SRS_RC_STRING_07_003: [ If vsnprintf failed to determine the total number of characters written, rc_string_create_with_vformat shall fail and return NULL. ]*/
             LogError("vsnprintf failed to determine the total number of characters written.");
         }
         else
-        {   
+        {
             if (string_length == INT_MAX)
             {
-                /*Codes_SRS_RC_STRING_07_009: [ If the resulting memory size requested for the `THANDLE(RC_STRING)`and the resulting formatted string results in an size_t overflow in `malloc_flex`, `rc_string_create_with_format` shall failand return `NULL`. ]*/
+                /*Codes_SRS_RC_STRING_07_009: [ If the resulting memory size requested for the THANDLE(RC_STRING)and the resulting formatted string results in an size_t overflow in malloc_flex, rc_string_create_with_vformat shall failand return NULL. ]*/
                 LogError("int overflowed, extra size is %zu, string_length_with_terminator=%zu", sizeof(RC_STRING_INTERNAL) - sizeof(RC_STRING) + (size_t)string_length + 1, (size_t)string_length + 1);
             }
             else
             {
-                /*Codes_SRS_RC_STRING_07_004: [ `rc_string_create_with_format` shall allocate memory for the `THANDLE(RC_STRING)`and the number of bytes for the resulting formatted string. ]*/
+                /*Codes_SRS_RC_STRING_07_004: [ rc_string_create_with_vformat shall allocate memory for the THANDLE(RC_STRING)and the number of bytes for the resulting formatted string. ]*/
                 THANDLE(RC_STRING) temp_result = THANDLE_MALLOC_WITH_EXTRA_SIZE(RC_STRING)(rc_string_dispose, sizeof(RC_STRING_INTERNAL) - sizeof(RC_STRING) + (size_t)string_length_with_terminator);
                 if (temp_result == NULL)
                 {
-                    /*Codes_SRS_RC_STRING_07_008: [ If any error occurs, `rc_string_create_with_format` shall fail and return `NULL`. ]*/
+                    /*Codes_SRS_RC_STRING_07_008: [ If any error occurs, rc_string_create_with_vformat shall fail and return NULL. ]*/
                     LogError("THANDLE_MALLOC_WITH_EXTRA_SIZE(RC_STRING) failed, extra size is %zu, string_length_with_terminator=%d", sizeof(RC_STRING_INTERNAL) - sizeof(RC_STRING) + (size_t)string_length_with_terminator, string_length_with_terminator);
                 }
                 else
@@ -168,25 +165,33 @@ THANDLE(RC_STRING) rc_string_create_with_format(const char* format, ...)
                     rc_string_internal->rc_string.string = rc_string_internal->copied_string;
                     rc_string_internal->storage_type = STRING_STORAGE_TYPE_COPIED;
 
-                    /*Codes_SRS_RC_STRING_07_005: [ `rc_string_create_with_format` shall fill in the bytes of the string by using `vsnprintf`. ]*/
+                    /*Codes_SRS_RC_STRING_07_005: [ rc_string_create_with_vformat shall fill in the bytes of the string by using vsnprintf. ]*/
                     int copy_string_length = vsnprintf(rc_string_internal->copied_string, string_length_with_terminator, format, args_copy);
                     if (copy_string_length < 0)
                     {
-                        /*Codes_SRS_RC_STRING_07_006: [ If `vsnprintf` failed to construct the resulting formatted string, `rc_string_create_with_format` shall fail and return `NULL`. ]*/
+                        /*Codes_SRS_RC_STRING_07_006: [ If vsnprintf failed to construct the resulting formatted string, rc_string_create_with_vformat shall fail and return NULL. ]*/
                         LogError("vsnprintf failed to get the resulting formatted string.");
                         THANDLE_FREE(RC_STRING)((void*)temp_result);
                     }
                     else
                     {
-                        /*Codes_SRS_RC_STRING_07_007: [ `rc_string_create_with_format` shall succeed and return a non - `NULL` handle. ]*/
+                        /*Codes_SRS_RC_STRING_07_007: [ rc_string_create_with_vformat shall succeed and return a non - NULL handle. ]*/
                         THANDLE_MOVE(RC_STRING)(&result, &temp_result);
                     }
                 }
             }
         }
-        va_end(args);
         va_end(args_copy);
     }
+    return result;
+}
+
+THANDLE(RC_STRING) rc_string_create_with_format_function(const char* format, ...)
+{
+    va_list va;
+    va_start(va, format);
+    THANDLE(RC_STRING) result = rc_string_create_with_vformat(format, va);
+    va_end(va);
     return result;
 }
 

--- a/tests/rc_string_ut/rc_string_ut.c
+++ b/tests/rc_string_ut/rc_string_ut.c
@@ -50,7 +50,7 @@ static int my_vsnprintf(void* s, size_t n, const char* format, va_list args)
     return vsnprintf(s, n, format, args);
 }
 
-static size_t my_strlen(const char* s) 
+static size_t my_strlen(const char* s)
 {
     return strlen(s);
 }
@@ -303,7 +303,12 @@ TEST_FUNCTION(rc_string_create_with_format_format_NULL_fails)
     // arrange
 
     // act
+#ifdef WIN32
     THANDLE(RC_STRING) rc_string = rc_string_create_with_format(NULL);
+#else
+    // On Linux, printf(NULL) generates a compiler warning, so instead just call the function that doesn't do the printf validation
+    THANDLE(RC_STRING) rc_string = rc_string_create_with_format_function(NULL);
+#endif
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -908,7 +913,7 @@ TEST_FUNCTION(rc_string_recreate_succeeds_2)
 {
     ///arrange
     const char source[] = "bla2";
-    
+
     STRICT_EXPECTED_CALL(mocked_strlen(source));
     STRICT_EXPECTED_CALL(malloc_flex(IGNORED_ARG, IGNORED_ARG, sizeof(char)));
 

--- a/tests/rc_string_ut/rc_string_ut.c
+++ b/tests/rc_string_ut/rc_string_ut.c
@@ -428,7 +428,12 @@ TEST_FUNCTION(rc_string_create_with_format_with_empty_string_succeeds)
     STRICT_EXPECTED_CALL(mocked_vsnprintf(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
 
     // act
+#ifdef WIN32
     THANDLE(RC_STRING) rc_string = rc_string_create_with_format("");
+#else
+    // On Linux, printf("") generates a compiler warning, so instead just call the function that doesn't do the printf validation
+    THANDLE(RC_STRING) rc_string = rc_string_create_with_format_function("");
+#endif
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());

--- a/tests/reals/real_rc_string.h
+++ b/tests/reals/real_rc_string.h
@@ -14,26 +14,25 @@
     MU_FOR_EACH_1(R2, \
         rc_string_create, \
         rc_string_create_with_move_memory, \
-        rc_string_create_with_custom_free \
+        rc_string_create_with_custom_free, \
+        rc_string_recreate, \
+        rc_string_create_with_vformat \
     ) \
     REGISTER_GLOBAL_MOCK_HOOK(THANDLE_MOVE(RC_STRING), THANDLE_MOVE(real_RC_STRING)) \
     REGISTER_GLOBAL_MOCK_HOOK(THANDLE_INITIALIZE(RC_STRING), THANDLE_INITIALIZE(real_RC_STRING)) \
     REGISTER_GLOBAL_MOCK_HOOK(THANDLE_INITIALIZE_MOVE(RC_STRING), THANDLE_INITIALIZE_MOVE(real_RC_STRING)) \
     REGISTER_GLOBAL_MOCK_HOOK(THANDLE_ASSIGN(RC_STRING), THANDLE_ASSIGN(real_RC_STRING)) \
 
-
 #include <stdint.h>
-
+#include <stdarg.h>
 
     typedef struct RC_STRING_TAG real_RC_STRING;
     THANDLE_TYPE_DECLARE(real_RC_STRING);
 
     THANDLE(RC_STRING) real_rc_string_create(const char* string);
-    THANDLE(RC_STRING) real_rc_string_create_with_format(const char* format, ...);
     THANDLE(RC_STRING) real_rc_string_create_with_move_memory(const char* string);
     THANDLE(RC_STRING) real_rc_string_create_with_custom_free(const char* string, RC_STRING_FREE_FUNC free_func, void* free_func_context);
     THANDLE(RC_STRING) real_rc_string_recreate(THANDLE(RC_STRING) source);
-
-
+    THANDLE(RC_STRING) real_rc_string_create_with_vformat(const char* format, va_list va);
 
 #endif //REAL_RC_STRING_H

--- a/tests/reals/real_rc_string.h
+++ b/tests/reals/real_rc_string.h
@@ -33,6 +33,8 @@
     THANDLE(RC_STRING) real_rc_string_create_with_move_memory(const char* string);
     THANDLE(RC_STRING) real_rc_string_create_with_custom_free(const char* string, RC_STRING_FREE_FUNC free_func, void* free_func_context);
     THANDLE(RC_STRING) real_rc_string_recreate(THANDLE(RC_STRING) source);
+
+    THANDLE(RC_STRING) real_rc_string_create_with_format_function(const char* format, ...);
     THANDLE(RC_STRING) real_rc_string_create_with_vformat(const char* format, va_list va);
 
 #endif //REAL_RC_STRING_H

--- a/tests/reals/real_rc_string_renames.h
+++ b/tests/reals/real_rc_string_renames.h
@@ -5,8 +5,9 @@ typedef struct RC_STRING_TAG real_RC_STRING;
 
 #define RC_STRING real_RC_STRING
 
-#define rc_string_create                    real_rc_string_create
-#define rc_string_create_with_format        real_rc_string_create_with_format
-#define rc_string_create_with_move_memory   real_rc_string_create_with_move_memory
-#define rc_string_create_with_custom_free   real_rc_string_create_with_custom_free
-#define rc_string_recreate                  real_rc_string_recreate
+#define rc_string_create                       real_rc_string_create
+#define rc_string_create_with_move_memory      real_rc_string_create_with_move_memory
+#define rc_string_create_with_custom_free      real_rc_string_create_with_custom_free
+#define rc_string_recreate                     real_rc_string_recreate
+#define rc_string_create_with_format_function  real_rc_string_create_with_format_function
+#define rc_string_create_with_vformat          real_rc_string_create_with_vformat


### PR DESCRIPTION
This makes `rc_string_create_with_format` a macro which calls `rc_string_create_with_format_function` which calls the mockable `rc_string_create_with_vformat`

Unit tests that use this will need to have this code (same as what we do for sprintf_char mocks):

```c
THANDLE(RC_STRING) rc_string_create_with_format_function(const char* format, ...)
{
    va_list va;
    va_start(va, format);
    THANDLE(RC_STRING) result = rc_string_create_with_vformat(format, va);
    va_end(va);
    return result;
}
```