### PR TITLE
Add RC_STRING_AS_CHARPTR macro

### DIFF
--- a/devdoc/rc_string_requirements.md
+++ b/devdoc/rc_string_requirements.md
@@ -7,31 +7,32 @@
 ## Exposed API
 
 ```c
-    typedef struct RC_STRING_TAG
-    {
-        const char* string;
-    } RC_STRING;
+typedef struct RC_STRING_TAG
+{
+    const char* string;
+} RC_STRING;
 
-    THANDLE_TYPE_DECLARE(RC_STRING);
+THANDLE_TYPE_DECLARE(RC_STRING);
 
-    typedef void (*RC_STRING_FREE_FUNC)(void* context);
+typedef void (*RC_STRING_FREE_FUNC)(void* context);
 
-    #define PRI_RC_STRING "s"
+#define PRI_RC_STRING "s"
 
-    #define RC_STRING_VALUE(rc) ((rc)->string)
-    #define RC_STRING_VALUE_OR_NULL(rc) (((rc) == NULL) ? "NULL" : (rc)->string)
+#define RC_STRING_VALUE(rc) ((rc)->string)
+#define RC_STRING_AS_CHARPTR(rc) (((rc) == NULL) ? NULL : (rc)->string)
+#define RC_STRING_VALUE_OR_NULL(rc) (((rc) == NULL) ? "NULL" : (rc)->string)
 
-    MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create, const char*, string);
-    MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_move_memory, const char*, string);
-    MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_custom_free, const char*, string, RC_STRING_FREE_FUNC, free_func, void*, free_func_context);
-    MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_recreate, THANDLE(RC_STRING), self);
+MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create, const char*, string);
+MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_move_memory, const char*, string);
+MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_custom_free, const char*, string, RC_STRING_FREE_FUNC, free_func, void*, free_func_context);
+MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_recreate, THANDLE(RC_STRING), self);
 
-    // Macro for mockable rc_string_create_with_vformat to verify the arguments as if printf was called
-    #define rc_string_create_with_format(format, ...) (0?printf((format), ## __VA_ARGS__):0, rc_string_create_with_format_function((format), ##__VA_ARGS__))
-    // The non-mockable function for rc_string_create_with_vformat (because we can't mock ... arguments)
-    THANDLE(RC_STRING) rc_string_create_with_format_function(const char* format, ...);
-    // The mockable function, called by rc_string_create_with_format_function
-    MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_vformat, const char*, format, va_list, va);
+// Macro for mockable rc_string_create_with_vformat to verify the arguments as if printf was called
+#define rc_string_create_with_format(format, ...) (0?printf((format), ## __VA_ARGS__):0, rc_string_create_with_format_function((format), ##__VA_ARGS__))
+// The non-mockable function for rc_string_create_with_vformat (because we can't mock ... arguments)
+THANDLE(RC_STRING) rc_string_create_with_format_function(const char* format, ...);
+// The mockable function, called by rc_string_create_with_format_function
+MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_vformat, const char*, format, va_list, va);
 ```
 
 ## RC_STRING_VALUE
@@ -45,6 +46,18 @@
 If `NULL` is used with `RC_STRING_VALUE`, the behavior is undefined.
 
 **SRS_RC_STRING_01_021: [** `RC_STRING_VALUE` shall print the `string` field of `rc`. **]**
+
+## RC_STRING_AS_CHARPTR
+
+```c
+#define RC_STRING_AS_CHARPTR(rc) ...
+```
+
+`RC_STRING_AS_CHARPTR` can be used to pass an `RC_STRING` which may be `NULL` to a function which takes a `const char*`. It handles making the `NULL` check before accessing the `string` field.
+
+**SRS_RC_STRING_42_001: [** If `rc` is `NULL` then `RC_STRING_AS_CHARPTR` shall return `NULL`. **]**
+
+**SRS_RC_STRING_42_002: [** If `rc` is non-`NULL` then `RC_STRING_AS_CHARPTR` shall return the `string` field of `rc`. **]**
 
 ## RC_STRING_VALUE_OR_NULL
 

--- a/inc/c_util/rc_string.h
+++ b/inc/c_util/rc_string.h
@@ -21,35 +21,39 @@ extern "C"
 {
 #endif
 
-    typedef struct RC_STRING_TAG
-    {
-        const char* string;
-    } RC_STRING;
+typedef struct RC_STRING_TAG
+{
+    const char* string;
+} RC_STRING;
 
-    THANDLE_TYPE_DECLARE(RC_STRING);
+THANDLE_TYPE_DECLARE(RC_STRING);
 
-    typedef void (*RC_STRING_FREE_FUNC)(void* context);
+typedef void (*RC_STRING_FREE_FUNC)(void* context);
 
 #define PRI_RC_STRING "s"
 
-    /*Codes_SRS_RC_STRING_01_021: [ RC_STRING_VALUE shall print the string field of rc. ]*/
+/*Codes_SRS_RC_STRING_01_021: [ RC_STRING_VALUE shall print the string field of rc. ]*/
 #define RC_STRING_VALUE(rc) ((rc)->string)
+
+/*Codes_SRS_RC_STRING_42_001: [ If rc is NULL then RC_STRING_AS_CHARPTR shall return NULL. ]*/
+/*Codes_SRS_RC_STRING_42_002: [ If rc is non-NULL then RC_STRING_AS_CHARPTR shall return the string field of rc. ]*/
+#define RC_STRING_AS_CHARPTR(rc) (((rc) == NULL) ? NULL : (rc)->string)
 
 /*Codes_SRS_RC_STRING_01_022: [ If rc is NULL, RC_STRING_VALUE_OR_NULL shall print NULL. ]*/
 /*Codes_SRS_RC_STRING_01_023: [ If rc is non NULL, RC_STRING_VALUE_OR_NULL shall print the string field of rc. ]*/
 #define RC_STRING_VALUE_OR_NULL(rc) (((rc) == NULL) ? "NULL" : (rc)->string)
 
-    MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create, const char*, string);
-    MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_move_memory, const char*, string);
-    MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_custom_free, const char*, string, RC_STRING_FREE_FUNC, free_func, void*, free_func_context);
-    MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_recreate, THANDLE(RC_STRING), self);
+MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create, const char*, string);
+MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_move_memory, const char*, string);
+MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_custom_free, const char*, string, RC_STRING_FREE_FUNC, free_func, void*, free_func_context);
+MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_recreate, THANDLE(RC_STRING), self);
 
-    // Macro for mockable rc_string_create_with_vformat to verify the arguments as if printf was called
-    #define rc_string_create_with_format(format, ...) (0?printf((format), ## __VA_ARGS__):0, rc_string_create_with_format_function((format), ##__VA_ARGS__))
-    // The non-mockable function for rc_string_create_with_vformat (because we can't mock ... arguments)
-    THANDLE(RC_STRING) rc_string_create_with_format_function(const char* format, ...);
-    // The mockable function, called by rc_string_create_with_format_function
-    MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_vformat, const char*, format, va_list, va);
+// Macro for mockable rc_string_create_with_vformat to verify the arguments as if printf was called
+#define rc_string_create_with_format(format, ...) (0?printf((format), ## __VA_ARGS__):0, rc_string_create_with_format_function((format), ##__VA_ARGS__))
+// The non-mockable function for rc_string_create_with_vformat (because we can't mock ... arguments)
+THANDLE(RC_STRING) rc_string_create_with_format_function(const char* format, ...);
+// The mockable function, called by rc_string_create_with_format_function
+MOCKABLE_FUNCTION(, THANDLE(RC_STRING), rc_string_create_with_vformat, const char*, format, va_list, va);
 
 #ifdef __cplusplus
 }

--- a/tests/rc_string_ut/rc_string_ut.c
+++ b/tests/rc_string_ut/rc_string_ut.c
@@ -93,6 +93,9 @@ MOCK_FUNCTION_END()
 MOCK_FUNCTION_WITH_CODE(, void, test_free_func_do_nothing, void*, context)
 MOCK_FUNCTION_END()
 
+MOCK_FUNCTION_WITH_CODE(, void, test_func_that_takes_charptr, const char*, str)
+MOCK_FUNCTION_END()
+
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
 TEST_SUITE_INITIALIZE(suite_initialize)
@@ -152,6 +155,7 @@ TEST_FUNCTION(RC_STRING_VALUE_works)
 {
     // arrange
     THANDLE(RC_STRING) a = rc_string_create("Lagavulin");
+    ASSERT_IS_NOT_NULL(a);
     char result[256];
 
     // act
@@ -159,6 +163,43 @@ TEST_FUNCTION(RC_STRING_VALUE_works)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, "I love Lagavulin", result);
+
+    // cleanup
+    THANDLE_ASSIGN(RC_STRING)(&a, NULL);
+}
+
+/* RC_STRING_AS_CHARPTR */
+
+/*Tests_SRS_RC_STRING_42_001: [ If rc is NULL then RC_STRING_AS_CHARPTR shall return NULL. ]*/
+TEST_FUNCTION(RC_STRING_AS_CHARPTR_with_NULL_works)
+{
+    // arrange
+    THANDLE(RC_STRING) null_string = NULL;
+
+    STRICT_EXPECTED_CALL(test_func_that_takes_charptr(NULL));
+
+    // act
+    test_func_that_takes_charptr(RC_STRING_AS_CHARPTR(null_string));
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/*Tests_SRS_RC_STRING_42_002: [ If rc is non-NULL then RC_STRING_AS_CHARPTR shall return the string field of rc. ]*/
+TEST_FUNCTION(RC_STRING_AS_CHARPTR_works)
+{
+    // arrange
+    THANDLE(RC_STRING) a = rc_string_create("this is a string");
+    ASSERT_IS_NOT_NULL(a);
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(test_func_that_takes_charptr("this is a string"));
+
+    // act
+    test_func_that_takes_charptr(RC_STRING_AS_CHARPTR(a));
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
     THANDLE_ASSIGN(RC_STRING)(&a, NULL);
@@ -185,6 +226,7 @@ TEST_FUNCTION(RC_STRING_VALUE_OR_NULL_works)
 {
     // arrange
     THANDLE(RC_STRING) a = rc_string_create("Laphroaig");
+    ASSERT_IS_NOT_NULL(a);
     char result[256];
 
     // act


### PR DESCRIPTION
This is a helper for calling a function like:
```c
int func(const char* str);
```
When you have a `THANDLE(RC_STRING)` which may or may not be `NULL`.
It is shorthand for:
```c
func((rc_str==NULL)?NULL:rc_str->string)
```