### PR TITLE
Make an extra check on index to satisfy Semmle error.

### DIFF
--- a/src/external_command_helper.c
+++ b/src/external_command_helper.c
@@ -75,8 +75,9 @@ IMPLEMENT_MOCKABLE_FUNCTION(, EXTERNAL_COMMAND_RESULT, external_command_helper_e
                     size_t original_buffer_len = strlen(command_output_buffer);
                     size_t buffer_len = strcspn(command_output_buffer, "\r\n");
 
-                    if (original_buffer_len == buffer_len)
+                    if (original_buffer_len == buffer_len || buffer_len >= COMMAND_OUTPUT_BUFFER_SIZE)
                     {
+                        // buffer_len >= COMMAND_OUTPUT_BUFFER_SIZE check is to suppress Semmle error Rule: SM01954 (cpp/unclear-array-index-validation).
                         // This means there was no newline at the end, which means the line was longer than our buffer
                         // Just fail because we don't expect that output
 


### PR DESCRIPTION
Semmle error:

```
##[error]1. Semmle Error SM01954 - File: deps/c-util/src/external_command_helper.c. Line: 90. Column 47. 
  Tool: Semmle: Rule: SM01954 (cpp/unclear-array-index-validation). 
  [String read by fgets](1) flows to here and is used in an array indexing expression, potentially causing an invalid access.
[String read by fgets](1) flows to here and is used in an array indexing expression, potentially causing an invalid access.
```

Added a check to ensure index is not >= array size, even though this should not happen, `strcspn` should always return a value < the array length. I expect this change will satisfy the tool.