### PR TITLE
Exclude tqueue_int_valgrind from running because valgrind gets stuck

### DIFF
--- a/build/linux/build_linux.sh
+++ b/build/linux/build_linux.sh
@@ -19,6 +19,6 @@ cmake -Drun_valgrind:BOOL=ON $build_root -Drun_unittests:BOOL=ON -Drun_int_tests
 make --jobs=$CORES
 
 # /*reenable with this task Task 10086393: reenable sm_chaos (https://msazure.visualstudio.com/One/_workitems/edit/10086393)*/
-ctest -j $CORES --output-on-failure -E "sm_int_helgrind|sm_int_valgrind"
+ctest -j $CORES --output-on-failure -E "sm_int_helgrind|sm_int_valgrind|tqueue_int_valgrind"
 
 popd 


### PR DESCRIPTION
Exclude tqueue_int_valgrind from running because valgrind gets stuck