### PR TITLE
Fix real_worker_thread to not have mock interlocked calls

### DIFF
--- a/tests/reals/real_worker_thread.c
+++ b/tests/reals/real_worker_thread.c
@@ -4,6 +4,7 @@
 #include "real_threadapi_renames.h" // IWYU pragma: keep
 #include "real_sm_renames.h" // IWYU pragma: keep
 #include "real_interlocked_hl_renames.h" // IWYU pragma: keep
+#include "real_interlocked_renames.h" // IWYU pragma: keep
 #include "real_sync_renames.h" // IWYU pragma: keep
 
 #include "real_worker_thread_renames.h" // IWYU pragma: keep


### PR DESCRIPTION
Missing real renames causes problems later with using real clds (which starts a worker thread)