### PR TITLE
Use `real_interlocked` in `real_channel`

### DIFF
--- a/tests/reals/real_channel.c
+++ b/tests/reals/real_channel.c
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 #include "real_gballoc_hl_renames.h"
+#include "real_interlocked_renames.h"
 #include "real_srw_lock_renames.h"
 #include "real_threadpool_renames.h"
 
 #include "real_doublylinkedlist_renames.h"
 
+#include "real_channel_internal_renames.h"
 #include "real_channel_renames.h"
 
 #include "../../src/channel.c"

--- a/tests/reals/real_channel_internal.c
+++ b/tests/reals/real_channel_internal.c
@@ -3,10 +3,12 @@
 #include "real_gballoc_hl_renames.h"
 #include "real_srw_lock_renames.h"
 #include "real_threadpool_renames.h"
+#include "real_interlocked_renames.h"
+#include "real_threadpool_renames.h"
 #include "real_doublylinkedlist_renames.h"
 #include "real_async_op_renames.h"
 #include "real_rc_ptr_renames.h"
- 
+
 #include "real_channel_common_renames.h"
 
 #include "real_channel_internal_renames.h"


### PR DESCRIPTION
If a test is mocking `interlocked.h` and using `real_channel.h`, `THANDLE` functions cause `interlocked` calls to get recorded.
 