### PR TITLE
Add "real_interlocked_renames.h" to rc_ptr.c

### DIFF
--- a/tests/reals/real_rc_ptr.c
+++ b/tests/reals/real_rc_ptr.c
@@ -3,4 +3,6 @@
 #include "real_gballoc_hl_renames.h"
 #include "real_rc_ptr_renames.h"
 
+#include "real_interlocked_renames.h"
+
 #include "../../src/rc_ptr.c"


### PR DESCRIPTION
This makes it so that we don't need to call out expects for interlocked functions if we also have to mock interlocked functions and rc_ptr functions in the same UT.